### PR TITLE
Remove duplicate link to podcast

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -42,8 +42,7 @@
 		>
 	</ul>
 	<p>
-		We also run the biannual <a href="https://sveltesummit.com/">Svelte Summit</a> conference and
-		host <a href="https://www.svelteradio.com/">the Svelte Radio podcast</a>.
+		We also run the biannual <a href="https://sveltesummit.com/">Svelte Summit</a> conference.
 	</p>
 </div>
 


### PR DESCRIPTION
We now have a big icon for the podcast just above, so no longer need to separately mention that we "also run the Svelte Radio podcast".