### PR TITLE
Cleanup component categories

### DIFF
--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -9,7 +9,7 @@
       "cli tools"
     ],
     "addedOn": "2021-03-31T00:00:00Z",
-    "category": "Integrations"
+    "category": "SvelteKit Adapters"
   },
   {
     "title": "SCR Svelte Client Router",
@@ -3785,7 +3785,7 @@
   },
   {
     "addedOn": "2021-02-26T23:46:44Z",
-    "category": "component sets",
+    "category": "Design System",
     "description": "A set of Fomantic-UI components for Svelte framework",
     "image": "",
     "npm": "svantic",
@@ -3840,7 +3840,7 @@
   },
   {
     "addedOn": "2021-04-05T11:52:00Z",
-    "category": "Unclassified",
+    "category": "",
     "description": "Performant and powerful remote data synchronization for Svelte",
     "image": "https://raw.githubusercontent.com/SvelteStack/svelte-query/main/docs/src/images/svelte-query-og.png",
     "npm": "@sveltestack/svelte-query",


### PR DESCRIPTION
Ref https://github.com/svelte-society/sveltesociety.dev/issues/218

There was an "Integration" and "Integrations" categories. I'd like to make one "SvelteKit Adapters", which is more specific and will allow us to link to https://sveltesociety.dev/ from the SvelteKit docs

There was only one in "component sets", which I think was accidentally putting a tag in a category

There were two "Unclassified" sections. One generated by an empty string and one where "Unclassified" was specifically written