### PR TITLE
Add tooling page

### DIFF
--- a/src/routes/_Header/Header.svelte
+++ b/src/routes/_Header/Header.svelte
@@ -3,14 +3,14 @@
 
 	import { page } from '$app/stores';
 	const linksLeft = [
-		['/', 'home'],
-		['/recipes', 'recipes'],
-		['/components', 'components']
+		['/about', 'about'],
+		['/components', 'components'],
+		['/tooling', 'tooling']
 	];
 	const linksRight = [
+		['/recipes', 'recipes'],
 		['/cheatsheet', 'cheat sheet'],
-		['/events', 'events'],
-		['/about', 'about']
+		['/events', 'events']
 	];
 </script>
 

--- a/src/routes/tooling/__layout.svelte
+++ b/src/routes/tooling/__layout.svelte
@@ -1,0 +1,22 @@
+<svelte:head>
+  <title>Svelte Society - Svelte Tooling</title>
+</svelte:head>
+<div class="wrapper">
+  <slot />
+</div>
+
+<style>
+  .wrapper {
+    max-width: 65ch;
+  }
+  .wrapper :global(h2), .wrapper :global(h3) {
+    margin-top: 2rem;
+    margin-bottom: 1.25rem;
+  }
+  .wrapper :global(p) {
+    margin-bottom: 1.25rem;
+  }
+  .wrapper :global(li) {
+    margin-bottom: 1.1rem;
+  }
+</style>

--- a/src/routes/tooling/index.svx
+++ b/src/routes/tooling/index.svx
@@ -1,0 +1,64 @@
+# Tooling
+
+## Bundler plugins
+
+- [rollup-plugin-svelte](https://github.com/sveltejs/rollup-plugin-svelte) (**official**)
+- [svelte-loader](https://github.com/sveltejs/svelte-loader) (**official**)
+- [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) (**official**)
+- [esbuild-svelte](https://github.com/EMH333/esbuild-svelte)
+  - esbuild plugin
+- [rollup-plugin-svelte-hot](https://github.com/rixo/rollup-plugin-svelte-hot)
+  - Rollup plugin
+  - HMR
+- [parcel-plugin-svelte](https://github.com/DeMoorJasper/parcel-plugin-svelte)
+  - Parcel plugin
+- [sveltify](https://github.com/tehshrike/sveltify)
+  - Browserify transform
+- [gulp-svelte](https://github.com/shinnn/gulp-svelte)
+  - gulp plugin
+- [meteor-svelte](https://github.com/meteor-svelte/meteor-svelte)
+  - Meteor plugin
+- [sveltejs-brunch](https://github.com/StarpTech/sveltejs-brunch)
+  - Brunch plugin
+- [rules_svelte](https://github.com/thelgevold/rules_svelte)
+  - Bazel Rules
+
+### Preprocessors
+
+- [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) (**official**)
+  - Supports PostCSS, SCSS, Less, Stylus, Coffeescript, TypeScript, and Pug.
+- [Less](https://github.com/ls-age/svelte-preprocess-less)
+- [modular-css](https://github.com/tivac/modular-css/tree/main/packages/svelte)
+- [Sass](https://github.com/ls-age/svelte-preprocess-sass)
+- [svelte-preprocess-css-hash](https://github.com/jiangfengming/svelte-preprocess-css-hash)
+  - Provides a mechanism to suffix css class names with a hash to avoid conflicts.
+- [svelte-preprocess-html-asset](https://github.com/jiangfengming/svelte-preprocess-html-asset)
+
+## Linting and formatting
+
+- [eslint-plugin-svelte3](https://github.com/sveltejs/eslint-plugin-svelte3) (**official**)
+- [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte) (**official**)
+  - Syntax formatting for Svelte
+- [svelte-check](https://www.npmjs.com/package/svelte-check) (**official**)
+  - Detects unused css
+  - Adds Svelte A11y hints
+  - Provides JavaScript/TypeScript diagnostics
+
+## Editor extensions
+
+- [svelte-vscode](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) (**official**)
+- [evanleck/vim-svelte](https://github.com/evanleck/vim-svelte)
+  - Supports Pre-processors
+- [vim-svelte-plugin](https://github.com/leafOfTree/vim-svelte-plugin)
+  - Vim syntax and indent plugin for .svelte files
+  - Supports Less/Sass/Scss, Pug, Coffee, TypeScript.
+  - A builtin foldexpr fold method.
+  - emmet-vim HTML/CSS/JavaScript filetype detection.
+- [coc-svelte](https://github.com/coc-extensions/coc-svelte)
+  - All of the above, also utilises the svelte language server
+- [web-mode.el](https://github.com/fxbois/web-mode)
+  - Emacs major mode including support for Svelte
+- [IntelliJ (WebStorm)](https://plugins.jetbrains.com/plugin/12375-svelte)
+- [Sublime Text: Svelte Syntax Highlighting](https://packagecontrol.io/packages/Svelte)
+- [SvelteNova](https://github.com/laosb/SvelteNova)
+  - Svelte language support for Nova Editor by Panic.


### PR DESCRIPTION
Copies much of the text from https://github.com/sveltejs/integrations in an effort to kill that repo and combine it with this one. I removed the "Home" link from the header to make room for this new link since the logo already links to the homepage. 