### PR TITLE
Add boilerplates page

### DIFF
--- a/src/routes/_Footer.svelte
+++ b/src/routes/_Footer.svelte
@@ -6,10 +6,11 @@
 
 <div class="shaded">
 	<footer class="wrapper">
-		<div>&copy; Svelte Society {year}</div>
-
-		<div>
-			Want to contribute? Pick up an issue on
+		<div class="centered">&copy; {year} Svelte Society
+			•
+			<a href="/about">Code of Conduct</a>
+			•
+			Contribute on
 			<a
 				class="ghlink"
 				href="https://github.com/svelte-society/sveltesociety-2021/"
@@ -24,6 +25,10 @@
 	.shaded {
 		max-width: 100%;
 		background: #f3f6f9;
+	}
+
+	.centered {
+		margin: 0 auto;
 	}
 
 	a {

--- a/src/routes/_Header/Header.svelte
+++ b/src/routes/_Header/Header.svelte
@@ -3,7 +3,7 @@
 
 	import { page } from '$app/stores';
 	const linksLeft = [
-		['/about', 'about'],
+		['/boilerplates', 'boilerplates'],
 		['/components', 'components'],
 		['/tooling', 'tooling']
 	];

--- a/src/routes/boilerplates/boilerplates.json
+++ b/src/routes/boilerplates/boilerplates.json
@@ -1,0 +1,782 @@
+[
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Boilerplate with TypeScript, Webpack, Storybook, Travis CI, SCSS, Babel, EsLint, Prettier, Jest",
+    "image": "",
+    "stars": 51,
+    "tags": [
+      "templates"
+    ],
+    "title": "agusID/boilerplate-svelte",
+    "url": "https://github.com/agusID/boilerplate-svelte"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "An example repo of a Svelte app that is IE11 compatible",
+    "image": "",
+    "stars": 27,
+    "tags": [
+      "templates"
+    ],
+    "title": "angelozehr/svelte-example-museums",
+    "url": "https://github.com/angelozehr/svelte-example-museums"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A truffle box for Svelte, a seed for building an Ethereum dapp using Truffle",
+    "image": "",
+    "stars": 30,
+    "tags": [
+      "templates"
+    ],
+    "title": "antony/svelte-box",
+    "url": "https://github.com/antony/svelte-box"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Typescript template for Svelte v3",
+    "image": "",
+    "stars": 21,
+    "tags": [
+      "templates"
+    ],
+    "title": "Axelen123/svelte-ts-template",
+    "url": "https://github.com/Axelen123/svelte-ts-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Component template with LiveReload and Jest unit testing",
+    "image": "",
+    "stars": 13,
+    "tags": [
+      "templates"
+    ],
+    "title": "beyonk-adventures/svelte-component-livereload-template",
+    "url": "https://github.com/beyonk-adventures/svelte-component-livereload-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A complete implementation with components, store, unit e2e tests and linting.",
+    "image": "",
+    "stars": 22,
+    "tags": [
+      "templates"
+    ],
+    "title": "TodoMVC Svelte",
+    "url": "https://github.com/blacksonic/todomvc-svelte"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Electron Svelte boilerplate",
+    "image": "",
+    "stars": 41,
+    "tags": [
+      "templates",
+      "electron"
+    ],
+    "title": "Blade67/Sveltron",
+    "url": "https://github.com/Blade67/Sveltron"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A template to create multi-page application powered by Webpack",
+    "image": "",
+    "stars": 11,
+    "tags": [
+      "templates"
+    ],
+    "title": "brandonxiang/svelte-webpack-mpa",
+    "url": "https://github.com/brandonxiang/svelte-webpack-mpa"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "The bare minimum boilerplate to use Svelte in electron",
+    "image": "",
+    "stars": 7,
+    "tags": [
+      "templates",
+      "electron"
+    ],
+    "title": "chuanqisun/svelte-electron-template",
+    "url": "https://github.com/chuanqisun/svelte-electron-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Minimal boilerplate example of Svelte with Typescript using Parcel. This also includes scss support",
+    "image": "",
+    "stars": 46,
+    "tags": [
+      "templates"
+    ],
+    "title": "dafn/svelte-typescript-parcel",
+    "url": "https://github.com/dafn/svelte-typescript-parcel"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Minimal boilerplate example of Svelte with Typescript using Rollup. This also includes scss support",
+    "image": "",
+    "stars": 78,
+    "tags": [
+      "templates"
+    ],
+    "title": "dafn/svelte-typescript-rollup",
+    "url": "https://github.com/dafn/svelte-typescript-rollup"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Sapper",
+    "description": "Starter Webpack template for Sapper apps using tailwindcss, postcss, purgecss, and svelte-preprocess.",
+    "image": "",
+    "stars": 7,
+    "tags": [
+      "templates"
+    ],
+    "title": "Sapper (Webpack) + TailwindCSS Template",
+    "url": "https://github.com/deanpress/sapper-tailwind-webpack-starter"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Skeleton app with Parcel, Jest, ESLint, Prettier, Babel, Wallaby",
+    "image": "",
+    "stars": 5,
+    "tags": [
+      "templates"
+    ],
+    "title": "devghost/svelte",
+    "url": "https://github.com/devghost/svelte"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte template with basic Babel setup for IE11 compatibility",
+    "image": "",
+    "stars": 0,
+    "tags": [
+      "templates"
+    ],
+    "title": "svelte-ie11",
+    "url": "https://github.com/elsonigo/svelte-ie11"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Typescript + Storybook + Webpack boilerplate",
+    "image": "",
+    "stars": 35,
+    "tags": [
+      "templates"
+    ],
+    "title": "farhan2106/svelte-typescript",
+    "url": "https://github.com/farhan2106/svelte-typescript"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Typescript + Storybook + Webpack with SSR boilerplate",
+    "image": "",
+    "stars": 8,
+    "tags": [
+      "templates"
+    ],
+    "title": "farhan2106/svelte-typescript-ssr",
+    "url": "https://github.com/farhan2106/svelte-typescript-ssr"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Starter for Svelte 3/rollup/typescript/vscode",
+    "image": "",
+    "stars": 45,
+    "tags": [
+      "templates"
+    ],
+    "title": "geakstr/svelte-3-rollup-typescript-vscode",
+    "url": "https://github.com/geakstr/svelte-3-rollup-typescript-vscode"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A small starter template to get up and running with Svelte v3",
+    "image": "",
+    "stars": 35,
+    "tags": [
+      "templates"
+    ],
+    "title": "Holben888/svelte-starter-template",
+    "url": "https://github.com/Holben888/svelte-starter-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte ecommerce - Headless, Authentication, Cart & Checkout, TailwindCSS, Server Rendered, Proxy + API Integrated, Animations, Stores, Lazy Loading, Loading Indicators, Carousel, Instant Search, Faceted Filters, 1 command deploy to production, Open Source, MIT license",
+    "image": "",
+    "stars": 215,
+    "tags": [
+      "templates"
+    ],
+    "title": "sapper-ecommerce",
+    "url": "https://github.com/itswadesh/sapper-ecommerce"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte + Storybook + Tailwind - Starter Template",
+    "image": "",
+    "stars": 161,
+    "tags": [
+      "templates"
+    ],
+    "title": "jerriclynsjohn/svelte-storybook-tailwind",
+    "url": "https://github.com/jerriclynsjohn/svelte-storybook-tailwind"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A template to help you start developing SPAs with Svelte and Firebase",
+    "image": "",
+    "stars": 80,
+    "tags": [
+      "templates"
+    ],
+    "title": "jorgegorka/svelte-firebase",
+    "url": "https://github.com/jorgegorka/svelte-firebase"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "SvelteJS and TailwindCSS template",
+    "image": "",
+    "stars": 1,
+    "tags": [
+      "templates"
+    ],
+    "title": "justinekizhak/svelte-tailwind-template",
+    "url": "https://github.com/justinekizhak/svelte-tailwind-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template for building phonegap hybrid applications with Svelte",
+    "image": "",
+    "stars": 8,
+    "tags": [
+      "templates",
+      "mobile"
+    ],
+    "title": "lpshanley/svelte-phonegap",
+    "url": "https://github.com/lpshanley/svelte-phonegap"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Minimal setup for building svelte as a web component module",
+    "image": "",
+    "stars": 1,
+    "tags": [
+      "templates"
+    ],
+    "title": "LunaTK/svelte-web-component-builder",
+    "url": "https://github.com/LunaTK/svelte-web-component-builder"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Tailwindcss v1 + Svelte v3 = <3",
+    "image": "",
+    "stars": 95,
+    "tags": [
+      "templates"
+    ],
+    "title": "marcograhl/tailwindcss-svelte-starter",
+    "url": "https://github.com/marcograhl/tailwindcss-svelte-starter"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte template with webpack, babel, eslint and scss. Using browserslist with corejs for legacy browser support",
+    "image": "",
+    "stars": 1,
+    "tags": [
+      "templates"
+    ],
+    "title": "svelte-webpack-babel-scss",
+    "url": "https://github.com/markoboy/svelte-webpack-babel-scss"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Build cybernetically enhanced web apps with Meteor and Svelte",
+    "image": "",
+    "stars": 92,
+    "tags": [
+      "components and libraries",
+      "stores and state"
+    ],
+    "title": "Svelte for Meteor",
+    "url": "https://github.com/meteor-svelte/meteor-svelte"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte + Tailwind = ❤",
+    "image": "",
+    "stars": 82,
+    "tags": [
+      "templates"
+    ],
+    "title": "muhajirdev/svelte-tailwind-template",
+    "url": "https://github.com/muhajirdev/svelte-tailwind-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Boilerplate code with Typescript and Sass bundled by Webpack",
+    "image": "",
+    "stars": 12,
+    "tags": [
+      "templates"
+    ],
+    "title": "n0th1ng-else/svelte-typescript-sass",
+    "url": "https://github.com/n0th1ng-else/svelte-typescript-sass"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Modern build process with Svelte, WebPack, PurgeCSS, code splitting, lazy loading...etc",
+    "image": "",
+    "stars": 0,
+    "tags": [
+      "templates",
+      "testing",
+      "typescript",
+      "code splitting",
+      "lazy loading",
+      "webpack",
+      "preprocessors"
+    ],
+    "title": "NazimAli2017/svelte-template",
+    "url": "https://github.com/NazimAli2017/svelte-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Offline-Capable todo list built with Svelte, PouchDB and CouchDB",
+    "image": "",
+    "stars": 32,
+    "tags": [
+      "templates"
+    ],
+    "title": "neighbourhoodie/svelte-pouchdb-couchdb",
+    "url": "https://github.com/neighbourhoodie/svelte-pouchdb-couchdb"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Sapper",
+    "description": "Starter Rollup template for Sapper apps with Firebase functions",
+    "image": "",
+    "stars": 13,
+    "tags": [
+      "ssr",
+      "templates"
+    ],
+    "title": "Sapper - Firebase functions",
+    "url": "https://github.com/nhristov/sapper-template-firebase"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Sapper",
+    "description": "Starter Rollup template for Sapper apps using postcss, purgecss, cssnano, tailwindcss and svelte-preprocess",
+    "image": "",
+    "stars": 17,
+    "tags": [
+      "templates"
+    ],
+    "title": "Sapper - PostCSS, Tailwind CSS, PurgeCSS, cssnano",
+    "url": "https://github.com/nhristov/sapper-template-rollup"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template with Typescript, Sass, Storybook, Webpack",
+    "image": "",
+    "stars": 13,
+    "tags": [
+      "templates"
+    ],
+    "title": "nitro52/svelte-typescript-sass-template",
+    "url": "https://github.com/nitro52/svelte-typescript-sass-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Starter to built Electron apps with Svelte and Better SQLite3",
+    "image": "",
+    "stars": 5,
+    "tags": [
+      "templates",
+      "electron",
+      "database"
+    ],
+    "title": "nye/svelte-electron-better-sqlite3-starter",
+    "url": "https://github.com/nye/svelte-electron-better-sqlite3-starter"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte webpack template with routing and lazy-loading",
+    "image": "",
+    "stars": 14,
+    "tags": [
+      "templates"
+    ],
+    "title": "OrdinaryJellyfish/svelte-routing-template",
+    "url": "https://github.com/OrdinaryJellyfish/svelte-routing-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte application boilerplate with Webpack, Sass, BabelJS, Fetch, PostCSS, Jest, and .Env",
+    "image": "",
+    "stars": 188,
+    "tags": [
+      "templates"
+    ],
+    "title": "pankod/svelte-boilerplate",
+    "url": "https://github.com/pankod/svelte-boilerplate"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A base for building Svelte component library",
+    "image": "",
+    "stars": 44,
+    "tags": [
+      "templates"
+    ],
+    "title": "patoi/svelte-component-library-template",
+    "url": "https://github.com/patoi/svelte-component-library-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte 3 starter with POI 12 and Prettier. Outputs web apps or web components",
+    "image": "",
+    "stars": 10,
+    "tags": [
+      "templates"
+    ],
+    "title": "pbastowski/svelte-poi-starter",
+    "url": "https://github.com/pbastowski/svelte-poi-starter"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte + Snowpack, TypeScript, SCSS, Jest with tight VSCode debugging",
+    "image": "",
+    "stars": 4,
+    "tags": [
+      "editor tools",
+      "templates",
+      "snowpack"
+    ],
+    "title": "svelte-ts-snowpack-vscode",
+    "url": "https://github.com/processtract/svelte-ts-snowpack-vscode"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Typescript monorepo for Svelte v3 (preprocess, template, types)",
+    "image": "",
+    "stars": 211,
+    "tags": [
+      "templates"
+    ],
+    "title": "pyoner/svelte-typescript",
+    "url": "https://github.com/pyoner/svelte-typescript"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Typescript monorepo for Svelte v3 (preprocess, template, types)",
+    "image": "",
+    "npm": "@pyoner/svelte-ts-preprocess",
+    "stars": 211,
+    "tags": [
+      "integrations",
+      "preprocessors"
+    ],
+    "title": "@pyoner/svelte-ts-preprocess",
+    "url": "https://github.com/pyoner/svelte-typescript"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Svelte App with Firebase Authentication for all purposes",
+    "image": "",
+    "stars": 35,
+    "tags": [
+      "templates"
+    ],
+    "title": "ricalamino/svelte-firebase-auth",
+    "url": "https://github.com/ricalamino/svelte-firebase-auth"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A template for building Electron apps with Svelte (**VERSION 2**)",
+    "image": "",
+    "stars": 72,
+    "tags": [
+      "templates",
+      "electron"
+    ],
+    "title": "Rich-Harris/svelte-template-electron",
+    "url": "https://github.com/Rich-Harris/svelte-template-electron"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Clone of official Svelte template with added HMR support using Nollup",
+    "image": "",
+    "stars": 45,
+    "tags": [
+      "templates"
+    ],
+    "title": "rixo/svelte-template-hot",
+    "url": "https://github.com/rixo/svelte-template-hot"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Yeoman generator generating a boilerplate Svelte.js app with all of svelte-preprocess' options",
+    "image": "",
+    "npm": "generator-svelte",
+    "stars": 15,
+    "tags": [
+      "templates",
+      "preprocessors"
+    ],
+    "title": "generator-svelte",
+    "url": "https://github.com/Samuel-Martineau/generator-svelte"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A boilerplate with Material, Babel, PostCSS, and Webpack",
+    "image": "",
+    "stars": 96,
+    "tags": [
+      "templates"
+    ],
+    "title": "Shyam-Chen/svelte-play",
+    "url": "https://github.com/Shyam-Chen/Svelte-Play"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A Svelte template for browserify",
+    "image": "",
+    "stars": 3,
+    "tags": [
+      "templates"
+    ],
+    "title": "soapdog/svelte-template-browserify",
+    "url": "https://github.com/soapdog/svelte-template-browserify"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Boilerplate template project for SPA router spaceavocado/svelte-router",
+    "image": "",
+    "stars": 6,
+    "tags": [
+      "templates"
+    ],
+    "title": "spaceavocado/svelte-router-template",
+    "url": "https://github.com/spaceavocado/svelte-router-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Boilerplate with Webpack, Cypress, Travis CI, Storybook, and SASS",
+    "image": "",
+    "stars": 15,
+    "tags": [
+      "templates"
+    ],
+    "title": "stephanepericat/svelte-boilerplate",
+    "url": "https://github.com/stephanepericat/svelte-boilerplate"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template with VSCode, Prettier, ESLint, Cypress, and Rollup",
+    "image": "",
+    "stars": 3,
+    "tags": [
+      "templates"
+    ],
+    "title": "SteveALee/svelte-code-cypress-project",
+    "url": "https://github.com/SteveALee/svelte-code-cypress-project"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A base for building shareable Svelte components",
+    "image": "",
+    "stars": 303,
+    "tags": [
+      "templates"
+    ],
+    "title": "sveltejs/component-template",
+    "url": "https://github.com/sveltejs/component-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Sapper",
+    "description": "Starter template for Sapper apps",
+    "image": "",
+    "stars": 623,
+    "tags": [
+      "templates"
+    ],
+    "title": "sveltejs/sapper-template",
+    "url": "https://github.com/sveltejs/sapper-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template for building basic applications with Svelte with rollup",
+    "image": "",
+    "stars": 800,
+    "tags": [
+      "templates"
+    ],
+    "title": "sveltejs/template",
+    "url": "https://github.com/sveltejs/template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template for building basic applications with Svelte and custom elements",
+    "image": "",
+    "stars": 17,
+    "tags": [
+      "templates"
+    ],
+    "title": "sveltejs/template-custom-element",
+    "url": "https://github.com/sveltejs/template-custom-element"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template for building basic Svelte applications with webpack",
+    "image": "",
+    "stars": 205,
+    "tags": [
+      "templates"
+    ],
+    "title": "sveltejs/template-webpack",
+    "url": "https://github.com/sveltejs/template-webpack"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Starter template for Cordova featuring hot reload",
+    "image": "",
+    "stars": 15,
+    "tags": [
+      "templates",
+      "mobile"
+    ],
+    "title": "syonip/svelte-cordova",
+    "url": "https://github.com/syonip/svelte-cordova"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A showcase app for all Ionic UI elements to create awesome mobile apps. Published as web app too.",
+    "image": "",
+    "stars": 113,
+    "tags": [
+      "components and libraries",
+      "component sets",
+      "templates",
+      "mobile"
+    ],
+    "title": "Ionic Svelte UI demo",
+    "url": "https://github.com/Tommertom/svelte-ionic-app"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Starter pack for Rollup, Typescript, and VSCode",
+    "image": "",
+    "stars": 6,
+    "tags": [
+      "templates"
+    ],
+    "title": "tonyrewin/svelte3-ts-boilerplate",
+    "url": "https://github.com/tonyrewin/svelte3-ts-boilerplate"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "Template with TypeScript, Babel, Jest, Svelte-Testing-Library, Eslint, and Prettier",
+    "image": "",
+    "stars": 4,
+    "tags": [
+      "templates"
+    ],
+    "title": "will-wow/svelte-typescript-template",
+    "url": "https://github.com/will-wow/svelte-typescript-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A base for building shareable Svelte 3 components",
+    "image": "",
+    "stars": 161,
+    "tags": [
+      "templates"
+    ],
+    "title": "YogliB/svelte-component-template",
+    "url": "https://github.com/YogliB/svelte-component-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Svelte",
+    "description": "A base for building shareable Svelte 3 components.",
+    "image": "",
+    "stars": 161,
+    "tags": [
+      "templates"
+    ],
+    "title": "svelte-component-template",
+    "url": "https://github.com/YogliB/svelte-component-template"
+  },
+  {
+    "addedOn": "2020-09-29T14:39:13Z",
+    "category": "Sapper",
+    "description": "Skip setup and start code with SENT (Sapper.js, Express.js, Node.js, Typescript) and other tools template",
+    "image": "",
+    "stars": 55,
+    "tags": [
+      "templates"
+    ],
+    "title": "Zimtir/SENT-template",
+    "url": "https://github.com/Zimtir/SENT-template"
+  }
+]

--- a/src/routes/boilerplates/index.svelte
+++ b/src/routes/boilerplates/index.svelte
@@ -1,0 +1,212 @@
+<script>
+  import ComponentCard from "$lib/components/ComponentIndex/Card.svelte";
+  import List from "$lib/components/ComponentIndex/CardList.svelte";
+  import Button from "$lib/components/ComponentIndex/ArrowButton.svelte";
+  import components from "./boilerplates.json";
+
+  let searchValue;
+  let searchTag;
+  const tags = Array.from(new Set(components.map(item => item.tags).flat()))
+  const allCategories = Array.from(new Set(components.map(item => item.category).flat()))
+  let filterTag = []
+  let filterCategory = null
+  let sorting = 'added_desc';
+
+  const intersection = (array1, array2) => {
+    return array1.filter(item => array2.includes(item))
+  }
+
+  $: dataToDisplay = components.filter(component => {
+    if (!searchValue && filterTag.length === 0 && filterCategory === null) return true
+
+    if (
+            (searchValue && !(component.title.toLowerCase().includes(searchValue.toLowerCase()) || component.description.toLowerCase().includes(searchValue.toLowerCase())))
+            || (filterTag.length > 0 && intersection(filterTag, component.tags).length === 0)
+            || (filterCategory !== null && component.category !== filterCategory)
+    ) {
+      return false
+    }
+
+    return true
+  }).sort((componentA, componentB) => {
+    switch (sorting) {
+      case "added_desc": return new Date(componentB.addedOn || '').getTime() - new Date(componentA.addedOn || '').getTime()
+      case "added_asc": return new Date(componentA.addedOn || '').getTime() - new Date(componentB.addedOn || '').getTime()
+      case "name_asc": return componentA.title.toLowerCase().localeCompare(componentB.title.toLowerCase())
+      case "name_desc": return componentB.title.toLowerCase().localeCompare(componentA.title.toLowerCase())
+      case "stars_desc": return (componentB.stars || 0) - (componentA.stars || 0)
+      case "stars_asc": return (componentA.stars || 0) - (componentB.stars || 0)
+    }
+  });
+  $: tagSearchResult = searchTag ? tags.filter(item => item.includes(searchTag)) : tags
+  $: categories = Array.from(new Set(dataToDisplay.map(item => item.category)))
+</script>
+
+<style>
+  .controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: Overpass;
+    position: relative;
+  }
+
+  .inputs {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    grid-gap: 0.5rem;
+    margin-right: 2rem;
+  }
+
+  .searchbar {
+    height: 100%;
+    width: 35%;
+    font-family: Overpass;
+    border-width: 0;
+    background: #f3f6f9 url(/search-icon.svg) 98% no-repeat;
+    margin: 0;
+    padding: 10px 15px;
+  }
+
+  .searchbar-count {
+    position: absolute;
+    top: 100%;
+    right: 0;
+  }
+
+  ul.popin {
+    padding: 0.5ex;
+    margin: 0;
+    font-size: 0.7em;
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  ul.popin li {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    text-transform: capitalize;
+  }
+  ul.popin li:hover {
+    background: #eee;
+    border-radius: 3px;
+  }
+  ul.popin li.tag-search {
+    position: sticky;
+    top: -0.5ex;
+    margin: 0 -0.5ex;
+    padding: 0.5ex;
+    border-radius: 4px;
+    background: white;
+  }
+  ul.popin li.tag-search input {
+    margin: 0;
+    background: #f3f6f9;
+    width: 100%;
+    min-width: 15ch;
+  }
+  ul.popin li.tag-search:hover {
+    background: white;
+  }
+  ul.popin.no-wrap li {
+    white-space: nowrap;
+  }
+
+  ul.popin li label {
+    display: flex;
+    align-items: center;
+    line-height: 0.7rem;
+    padding: 0.8ex;
+  }
+
+  ul.popin li input {
+    flex: 0;
+    margin: 0 1ex 0 0;
+  }
+
+  @media screen and (max-width: 1024px) {
+    .controls {
+      flex-flow: column-reverse;
+    }
+
+    .inputs {
+      align-self: flex-start;
+      width: 100%;
+      grid-template-columns: repeat(3, auto);
+    }
+
+    .searchbar {
+      align-self: flex-end;
+      margin-bottom: 1ex;
+    }
+  }
+
+  @media screen and (max-width: 700px) {
+    .controls {
+      align-items: stretch;
+    }
+
+    .inputs {
+      grid-template-columns: auto;
+    }
+
+    .searchbar {
+      width: auto;
+      align-self: stretch;
+    }
+  }
+</style>
+
+<main class="wrapper">
+  <h1>Boilerplates</h1>
+  <div class="controls">
+    <div class="inputs">
+      <Button active={filterTag.length > 0}>
+        Tags {#if filterTag.length > 0}<small>({filterTag.length})</small>{/if}
+        <ul slot="menu" role="menu" class="popin">
+          <li class="tag-search"><input placeholder="Search for tags..." bind:value={searchTag} /></li>
+          {#each tagSearchResult as tag}
+            <li><label><input type="checkbox" bind:group={filterTag} value={tag}> {tag}</label></li>
+          {/each}
+        </ul>
+      </Button>
+      <Button active={filterCategory !== null}>
+        Categories
+        <ul slot="menu" role="menu" class="popin">
+          <li><label><input type="radio" bind:group={filterCategory} value={null}> All</label></li>
+          {#each allCategories as category}
+            <li><label><input type="radio" bind:group={filterCategory} value={category}> {category||"Unclassified"}</label></li>
+          {/each}
+        </ul>
+      </Button>
+      <Button on:click={() => location.href = "/help/components"}>Submit a component</Button>
+      <Button active={sorting !== ''}>
+        Sort
+        <ul slot="menu" role="menu" class="popin no-wrap">
+            <li><label><input type="radio" bind:group={sorting} value="added_desc"> Last Added first</label></li>
+            <li><label><input type="radio" bind:group={sorting} value="added_asc"> Oldest first</label></li>
+            <li><label><input type="radio" bind:group={sorting} value="stars_desc"> Stars Desc</label></li>
+            <li><label><input type="radio" bind:group={sorting} value="stars_asc"> Stars Asc</label></li>
+            <li><label><input type="radio" bind:group={sorting} value="name_asc"> Name Asc</label></li>
+            <li><label><input type="radio" bind:group={sorting} value="name_desc"> Name Desc</label></li>
+        </ul>
+      </Button>
+    </div>
+
+    <input
+      class="searchbar"
+      type="text"
+      placeholder="Search for components..."
+      bind:value={searchValue} />
+    <span class="searchbar-count">{dataToDisplay.length} result{#if dataToDisplay.length !== 1}s{/if}</span>
+  </div>
+  <hr />
+  {#each categories as category}
+    <List title={category||"Unclassified"}>
+      {#each dataToDisplay.filter(d => d.category === category) as data}
+        <ComponentCard {...data} />
+      {/each}
+    </List>
+  {/each}
+</main>

--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -103,18 +103,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Boilerplate with TypeScript, Webpack, Storybook, Travis CI, SCSS, Babel, EsLint, Prettier, Jest",
-    "image": "",
-    "stars": 51,
-    "tags": [
-      "templates"
-    ],
-    "title": "agusID/boilerplate-svelte",
-    "url": "https://github.com/agusID/boilerplate-svelte"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Forms & User Input",
     "description": "Svelte tags input is a component to use with Svelte and easily enter tags and customize some functions",
     "image": "",
@@ -293,30 +281,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "An example repo of a Svelte app that is IE11 compatible",
-    "image": "",
-    "stars": 27,
-    "tags": [
-      "templates"
-    ],
-    "title": "angelozehr/svelte-example-museums",
-    "url": "https://github.com/angelozehr/svelte-example-museums"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A truffle box for Svelte, a seed for building an Ethereum dapp using Truffle",
-    "image": "",
-    "stars": 30,
-    "tags": [
-      "templates"
-    ],
-    "title": "antony/svelte-box",
-    "url": "https://github.com/antony/svelte-box"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Forms & User Input",
     "description": "Generate dynamic forms for sveltejs, Sveltekit, Routify and Sapper",
     "image": "",
@@ -345,18 +309,6 @@
     ],
     "title": "svelte-websocket-store",
     "url": "https://github.com/arlac77/svelte-websocket-store"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Typescript template for Svelte v3",
-    "image": "",
-    "stars": 21,
-    "tags": [
-      "templates"
-    ],
-    "title": "Axelen123/svelte-ts-template",
-    "url": "https://github.com/Axelen123/svelte-ts-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -399,18 +351,6 @@
     ],
     "title": "@beyonk/svelte-carousel",
     "url": "https://github.com/beyonk-adventures/svelte-carousel"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Component template with LiveReload and Jest unit testing",
-    "image": "",
-    "stars": 13,
-    "tags": [
-      "templates"
-    ],
-    "title": "beyonk-adventures/svelte-component-livereload-template",
-    "url": "https://github.com/beyonk-adventures/svelte-component-livereload-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -538,31 +478,7 @@
     "title": "@beyonk/svelte-trustpilot",
     "url": "https://github.com/beyonk-adventures/svelte-trustpilot"
   },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A complete implementation with components, store, unit e2e tests and linting.",
-    "image": "",
-    "stars": 22,
-    "tags": [
-      "templates"
-    ],
-    "title": "TodoMVC Svelte",
-    "url": "https://github.com/blacksonic/todomvc-svelte"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Electron Svelte boilerplate",
-    "image": "",
-    "stars": 41,
-    "tags": [
-      "templates",
-      "electron"
-    ],
-    "title": "Blade67/Sveltron",
-    "url": "https://github.com/Blade67/Sveltron"
-  },
+
   {
     "addedOn": "2020-09-29T14:39:13Z",
     "category": "Routers",
@@ -575,18 +491,6 @@
     ],
     "title": "@bjornlu/svelte-router",
     "url": "https://github.com/bluwy/svelte-router"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A template to create multi-page application powered by Webpack",
-    "image": "",
-    "stars": 11,
-    "tags": [
-      "templates"
-    ],
-    "title": "brandonxiang/svelte-webpack-mpa",
-    "url": "https://github.com/brandonxiang/svelte-webpack-mpa"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -673,19 +577,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "The bare minimum boilerplate to use Svelte in electron",
-    "image": "",
-    "stars": 7,
-    "tags": [
-      "templates",
-      "electron"
-    ],
-    "title": "chuanqisun/svelte-electron-template",
-    "url": "https://github.com/chuanqisun/svelte-electron-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Developer Experience",
     "description": "Svelte support for (Neo)Vim",
     "image": "",
@@ -728,30 +619,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Minimal boilerplate example of Svelte with Typescript using Parcel. This also includes scss support",
-    "image": "",
-    "stars": 46,
-    "tags": [
-      "templates"
-    ],
-    "title": "dafn/svelte-typescript-parcel",
-    "url": "https://github.com/dafn/svelte-typescript-parcel"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Minimal boilerplate example of Svelte with Typescript using Rollup. This also includes scss support",
-    "image": "",
-    "stars": 78,
-    "tags": [
-      "templates"
-    ],
-    "title": "dafn/svelte-typescript-rollup",
-    "url": "https://github.com/dafn/svelte-typescript-rollup"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Data Visualisation",
     "description": "A table with sorting and filtering",
     "image": "",
@@ -791,30 +658,6 @@
     ],
     "title": "svelte-ruler",
     "url": "https://github.com/daybrush/ruler/tree/master/packages/svelte-ruler"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter Webpack template for Sapper apps using tailwindcss, postcss, purgecss, and svelte-preprocess.",
-    "image": "",
-    "stars": 7,
-    "tags": [
-      "templates"
-    ],
-    "title": "Sapper (Webpack) + TailwindCSS Template",
-    "url": "https://github.com/deanpress/sapper-tailwind-webpack-starter"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Skeleton app with Parcel, Jest, ESLint, Prettier, Babel, Wallaby",
-    "image": "",
-    "stars": 5,
-    "tags": [
-      "templates"
-    ],
-    "title": "devghost/svelte",
-    "url": "https://github.com/devghost/svelte"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -886,18 +729,6 @@
     ],
     "title": "svelte-dev-helper",
     "url": "https://github.com/ekhaled/svelte-dev-helper"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "svelte template with basic babel setup for ie11 compatibility",
-    "image": "",
-    "stars": 0,
-    "tags": [
-      "templates"
-    ],
-    "title": "svelte-ie11",
-    "url": "https://github.com/elsonigo/svelte-ie11"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -983,30 +814,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Typescript + Storybook + Webpack boilerplate",
-    "image": "",
-    "stars": 35,
-    "tags": [
-      "templates"
-    ],
-    "title": "farhan2106/svelte-typescript",
-    "url": "https://github.com/farhan2106/svelte-typescript"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Typescript + Storybook + Webpack with SSR boilerplate",
-    "image": "",
-    "stars": 8,
-    "tags": [
-      "templates"
-    ],
-    "title": "farhan2106/svelte-typescript-ssr",
-    "url": "https://github.com/farhan2106/svelte-typescript-ssr"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "User Interaction",
     "description": "A simple, small, and content-agnostic modal for Svelte",
     "image": "",
@@ -1031,18 +838,6 @@
     ],
     "title": "@urql/svelte",
     "url": "https://github.com/FormidableLabs/urql/tree/master/packages/svelte-urql"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter for Svelte 3/rollup/typescript/vscode",
-    "image": "",
-    "stars": 45,
-    "tags": [
-      "templates"
-    ],
-    "title": "geakstr/svelte-3-rollup-typescript-vscode",
-    "url": "https://github.com/geakstr/svelte-3-rollup-typescript-vscode"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -1155,18 +950,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A small starter template to get up and running with Svelte v3",
-    "image": "",
-    "stars": 35,
-    "tags": [
-      "templates"
-    ],
-    "title": "Holben888/svelte-starter-template",
-    "url": "https://github.com/Holben888/svelte-starter-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Design System",
     "description": "Svelte Material UI Components",
     "image": "",
@@ -1235,18 +1018,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte ecommerce - Headless, Authentication, Cart & Checkout, TailwindCSS, Server Rendered, Proxy + API Integrated, Animations, Stores, Lazy Loading, Loading Indicators, Carousel, Instant Search, Faceted Filters, 1 command deploy to production, Open Source, MIT license",
-    "image": "",
-    "stars": 215,
-    "tags": [
-      "templates"
-    ],
-    "title": "sapper-ecommerce",
-    "url": "https://github.com/itswadesh/sapper-ecommerce"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Forms & User Input",
     "description": "Flatpickr component for Svelte",
     "image": "",
@@ -1298,18 +1069,6 @@
     ],
     "title": "@jamen/svelte-router",
     "url": "https://github.com/jamen/svelte-router"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte + Storybook + Tailwind - Starter Template",
-    "image": "",
-    "stars": 161,
-    "tags": [
-      "templates"
-    ],
-    "title": "jerriclynsjohn/svelte-storybook-tailwind",
-    "url": "https://github.com/jerriclynsjohn/svelte-storybook-tailwind"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -1381,18 +1140,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A template to help you start developing SPAs with Svelte and Firebase",
-    "image": "",
-    "stars": 80,
-    "tags": [
-      "templates"
-    ],
-    "title": "jorgegorka/svelte-firebase",
-    "url": "https://github.com/jorgegorka/svelte-firebase"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Routers",
     "description": "Svelte router specially designed for Single Page Applications (SPA)",
     "image": "",
@@ -1403,18 +1150,6 @@
     ],
     "title": "svelte-router-spa",
     "url": "https://github.com/jorgegorka/svelte-router"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "SvelteJS and TailwindCSS template",
-    "image": "",
-    "stars": 1,
-    "tags": [
-      "templates"
-    ],
-    "title": "justinekizhak/svelte-tailwind-template",
-    "url": "https://github.com/justinekizhak/svelte-tailwind-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -1666,19 +1401,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template for building phonegap hybrid applications with Svelte",
-    "image": "",
-    "stars": 8,
-    "tags": [
-      "templates",
-      "mobile"
-    ],
-    "title": "lpshanley/svelte-phonegap",
-    "url": "https://github.com/lpshanley/svelte-phonegap"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Developer Experience",
     "description": "LESS preprocessor",
     "image": "",
@@ -1721,18 +1443,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Minimal setup for building svelte as a web component module",
-    "image": "",
-    "stars": 1,
-    "tags": [
-      "templates"
-    ],
-    "title": "LunaTK/svelte-web-component-builder",
-    "url": "https://github.com/LunaTK/svelte-web-component-builder"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Routers",
     "description": "Easy router for Svelte framework",
     "image": "",
@@ -1759,30 +1469,6 @@
     ],
     "title": "svelte-inview",
     "url": "https://github.com/maciekgrzybek/svelte-inview"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Tailwindcss v1 + Svelte v3 = <3",
-    "image": "",
-    "stars": 95,
-    "tags": [
-      "templates"
-    ],
-    "title": "marcograhl/tailwindcss-svelte-starter",
-    "url": "https://github.com/marcograhl/tailwindcss-svelte-starter"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte template with webpack, babel, eslint and scss. Using browserslist with corejs for legacy browser support",
-    "image": "",
-    "stars": 1,
-    "tags": [
-      "templates"
-    ],
-    "title": "svelte-webpack-babel-scss",
-    "url": "https://github.com/markoboy/svelte-webpack-babel-scss"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -1855,19 +1541,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Build cybernetically enhanced web apps with Meteor and Svelte",
-    "image": "",
-    "stars": 92,
-    "tags": [
-      "components and libraries",
-      "stores and state"
-    ],
-    "title": "Svelte for Meteor",
-    "url": "https://github.com/meteor-svelte/meteor-svelte"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Data Visualisation",
     "description": "a framework for mostly-reusable graphics with Svelte",
     "image": "",
@@ -1921,30 +1594,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte + Tailwind = ❤",
-    "image": "",
-    "stars": 82,
-    "tags": [
-      "templates"
-    ],
-    "title": "muhajirdev/svelte-tailwind-template",
-    "url": "https://github.com/muhajirdev/svelte-tailwind-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Boilerplate code with Typescript and Sass bundled by Webpack",
-    "image": "",
-    "stars": 12,
-    "tags": [
-      "templates"
-    ],
-    "title": "n0th1ng-else/svelte-typescript-sass",
-    "url": "https://github.com/n0th1ng-else/svelte-typescript-sass"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "Arrange infinite card elements according to various layout types like masonry",
     "image": "",
@@ -1955,73 +1604,6 @@
     ],
     "title": "@egjs/svelte-infinitegrid",
     "url": "https://github.com/naver/egjs-infinitegrid/blob/master/packages/svelte-infinitegrid"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Modern build process with Svelte, WebPack, PurgeCSS, code splitting, lazy loading...etc",
-    "image": "",
-    "stars": 0,
-    "tags": [
-      "templates",
-      "testing",
-      "typescript",
-      "code splitting",
-      "lazy loading",
-      "webpack",
-      "preprocessors"
-    ],
-    "title": "NazimAli2017/svelte-template",
-    "url": "https://github.com/NazimAli2017/svelte-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Offline-Capable todo list built with Svelte, PouchDB and CouchDB",
-    "image": "",
-    "stars": 32,
-    "tags": [
-      "templates"
-    ],
-    "title": "neighbourhoodie/svelte-pouchdb-couchdb",
-    "url": "https://github.com/neighbourhoodie/svelte-pouchdb-couchdb"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter Rollup template for Sapper apps with Firebase functions",
-    "image": "",
-    "stars": 13,
-    "tags": [
-      "ssr",
-      "templates"
-    ],
-    "title": "Sapper - Firebase functions",
-    "url": "https://github.com/nhristov/sapper-template-firebase"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter Rollup template for Sapper apps using postcss, purgecss, cssnano, tailwindcss and svelte-preprocess",
-    "image": "",
-    "stars": 17,
-    "tags": [
-      "templates"
-    ],
-    "title": "Sapper - PostCSS, Tailwind CSS, PurgeCSS, cssnano",
-    "url": "https://github.com/nhristov/sapper-template-rollup"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template with Typescript, Sass, Storybook, Webpack",
-    "image": "",
-    "stars": 13,
-    "tags": [
-      "templates"
-    ],
-    "title": "nitro52/svelte-typescript-sass-template",
-    "url": "https://github.com/nitro52/svelte-typescript-sass-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2040,20 +1622,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter to built Electron apps with Svelte and Better SQLite3",
-    "image": "",
-    "stars": 5,
-    "tags": [
-      "templates",
-      "electron",
-      "database"
-    ],
-    "title": "nye/svelte-electron-better-sqlite3-starter",
-    "url": "https://github.com/nye/svelte-electron-better-sqlite3-starter"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "A multiseries, SVG progressbar component made with Svelte",
     "image": "",
@@ -2065,30 +1633,6 @@
     ],
     "title": "@okrad/svelte-progressbar",
     "url": "https://github.com/okrad/svelte-progressbar"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte webpack template with routing and lazy-loading",
-    "image": "",
-    "stars": 14,
-    "tags": [
-      "templates"
-    ],
-    "title": "OrdinaryJellyfish/svelte-routing-template",
-    "url": "https://github.com/OrdinaryJellyfish/svelte-routing-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte application boilerplate with Webpack, Sass, BabelJS, Fetch, PostCSS, Jest, and .Env",
-    "image": "",
-    "stars": 188,
-    "tags": [
-      "templates"
-    ],
-    "title": "pankod/svelte-boilerplate",
-    "url": "https://github.com/pankod/svelte-boilerplate"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2148,18 +1692,6 @@
     ],
     "title": "yrv",
     "url": "https://github.com/pateketrueke/yrv"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A base for building Svelte component library",
-    "image": "",
-    "stars": 44,
-    "tags": [
-      "templates"
-    ],
-    "title": "patoi/svelte-component-library-template",
-    "url": "https://github.com/patoi/svelte-component-library-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2300,18 +1832,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte 3 starter with POI 12 and Prettier. Outputs web apps or web components",
-    "image": "",
-    "stars": 10,
-    "tags": [
-      "templates"
-    ],
-    "title": "pbastowski/svelte-poi-starter",
-    "url": "https://github.com/pbastowski/svelte-poi-starter"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "a matchMedia plugin for Svelte 3",
     "image": "",
@@ -2435,20 +1955,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte + Snowpack, TypeScript, SCSS, Jest with tight VSCode debugging",
-    "image": "",
-    "stars": 4,
-    "tags": [
-      "editor tools",
-      "templates",
-      "snowpack"
-    ],
-    "title": "svelte-ts-snowpack-vscode",
-    "url": "https://github.com/processtract/svelte-ts-snowpack-vscode"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Developer Experience",
     "description": "Creates a new Svelte component from higlighted text",
     "image": "",
@@ -2485,32 +1991,6 @@
     ],
     "title": "svelte-hash-router",
     "url": "https://github.com/pynnl/svelte-hash-router"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Typescript monorepo for Svelte v3 (preprocess, template, types)",
-    "image": "",
-    "stars": 211,
-    "tags": [
-      "templates"
-    ],
-    "title": "pyoner/svelte-typescript",
-    "url": "https://github.com/pyoner/svelte-typescript"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Typescript monorepo for Svelte v3 (preprocess, template, types)",
-    "image": "",
-    "npm": "@pyoner/svelte-ts-preprocess",
-    "stars": 211,
-    "tags": [
-      "integrations",
-      "preprocessors"
-    ],
-    "title": "@pyoner/svelte-ts-preprocess",
-    "url": "https://github.com/pyoner/svelte-typescript"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2581,18 +2061,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Svelte App with Firebase Authentication for all purposes",
-    "image": "",
-    "stars": 35,
-    "tags": [
-      "templates"
-    ],
-    "title": "ricalamino/svelte-firebase-auth",
-    "url": "https://github.com/ricalamino/svelte-firebase-auth"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Data Visualisation",
     "description": "Experimental charting library for Svelte",
     "image": "",
@@ -2604,31 +2072,6 @@
     ],
     "title": "@sveltejs/pancake",
     "url": "https://github.com/Rich-Harris/pancake"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A template for building Electron apps with Svelte (**VERSION 2**)",
-    "image": "",
-    "stars": 72,
-    "tags": [
-      "templates",
-      "electron"
-    ],
-    "title": "Rich-Harris/svelte-template-electron",
-    "url": "https://github.com/Rich-Harris/svelte-template-electron"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Clone of official Svelte template with added HMR support using Nollup",
-    "image": "",
-    "stars": 45,
-    "tags": [
-      "templates"
-    ],
-    "title": "rixo/svelte-template-hot",
-    "url": "https://github.com/rixo/svelte-template-hot"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2701,20 +2144,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Yeoman generator generating a boilerplate Svelte.js app with all of svelte-preprocess' options",
-    "image": "",
-    "npm": "generator-svelte",
-    "stars": 15,
-    "tags": [
-      "templates",
-      "preprocessors"
-    ],
-    "title": "generator-svelte",
-    "url": "https://github.com/Samuel-Martineau/generator-svelte"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "User Interaction",
     "description": "A dependency free multiple item JavaScript carousel",
     "image": "",
@@ -2770,18 +2199,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A boilerplate with Material, Babel, PostCSS, and Webpack",
-    "image": "",
-    "stars": 96,
-    "tags": [
-      "templates"
-    ],
-    "title": "Shyam-Chen/svelte-play",
-    "url": "https://github.com/Shyam-Chen/Svelte-Play"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "Marquee fully responsive and adaptive for Svelte",
     "image": "",
@@ -2821,18 +2238,6 @@
     ],
     "title": "svelte-infinite-loading",
     "url": "https://github.com/Skayo/svelte-infinite-loading"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A Svelte template for browserify",
-    "image": "",
-    "stars": 3,
-    "tags": [
-      "templates"
-    ],
-    "title": "soapdog/svelte-template-browserify",
-    "url": "https://github.com/soapdog/svelte-template-browserify"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2876,18 +2281,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Boilerplate template project for SPA router spaceavocado/svelte-router",
-    "image": "",
-    "stars": 6,
-    "tags": [
-      "templates"
-    ],
-    "title": "spaceavocado/svelte-router-template",
-    "url": "https://github.com/spaceavocado/svelte-router-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "Component to easily generate multitone images",
     "image": "",
@@ -2912,30 +2305,6 @@
     ],
     "title": "svelte-progresscircle",
     "url": "https://github.com/stephane-vanraes/svelte-progresscircle"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Boilerplate with Webpack, Cypress, Travis CI, Storybook, and SASS",
-    "image": "",
-    "stars": 15,
-    "tags": [
-      "templates"
-    ],
-    "title": "stephanepericat/svelte-boilerplate",
-    "url": "https://github.com/stephanepericat/svelte-boilerplate"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template with VSCode, Prettier, ESLint, Cypress, and Rollup",
-    "image": "",
-    "stars": 3,
-    "tags": [
-      "templates"
-    ],
-    "title": "SteveALee/svelte-code-cypress-project",
-    "url": "https://github.com/SteveALee/svelte-code-cypress-project"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -2979,18 +2348,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A base for building shareable Svelte components",
-    "image": "",
-    "stars": 303,
-    "tags": [
-      "templates"
-    ],
-    "title": "sveltejs/component-template",
-    "url": "https://github.com/sveltejs/component-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "User Interaction",
     "description": "Svelte actions for cross-platform gesture detection (work in progress)",
     "image": "",
@@ -3029,18 +2386,6 @@
     ],
     "title": "language-tools",
     "url": "https://github.com/sveltejs/language-tools"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter template for Sapper apps",
-    "image": "",
-    "stars": 623,
-    "tags": [
-      "templates"
-    ],
-    "title": "sveltejs/sapper-template",
-    "url": "https://github.com/sveltejs/sapper-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -3111,55 +2456,6 @@
     ],
     "title": "@sveltejs/svelte-virtual-list",
     "url": "https://github.com/sveltejs/svelte-virtual-list"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template for building basic applications with Svelte with rollup",
-    "image": "",
-    "stars": 800,
-    "tags": [
-      "templates"
-    ],
-    "title": "sveltejs/template",
-    "url": "https://github.com/sveltejs/template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template for building basic applications with Svelte and custom elements",
-    "image": "",
-    "stars": 17,
-    "tags": [
-      "templates"
-    ],
-    "title": "sveltejs/template-custom-element",
-    "url": "https://github.com/sveltejs/template-custom-element"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template for building basic Svelte applications with webpack",
-    "image": "",
-    "stars": 205,
-    "tags": [
-      "templates"
-    ],
-    "title": "sveltejs/template-webpack",
-    "url": "https://github.com/sveltejs/template-webpack"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter template for Cordova featuring hot reload",
-    "image": "",
-    "stars": 15,
-    "tags": [
-      "templates",
-      "mobile"
-    ],
-    "title": "syonip/svelte-cordova",
-    "url": "https://github.com/syonip/svelte-cordova"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
@@ -3300,33 +2596,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A showcase app for all Ionic UI elements to create awesome mobile apps. Published as web app too.",
-    "image": "",
-    "stars": 113,
-    "tags": [
-      "components and libraries",
-      "component sets",
-      "templates",
-      "mobile"
-    ],
-    "title": "Ionic Svelte UI demo",
-    "url": "https://github.com/Tommertom/svelte-ionic-app"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Starter pack for Rollup, Typescript, and VSCode",
-    "image": "",
-    "stars": 6,
-    "tags": [
-      "templates"
-    ],
-    "title": "tonyrewin/svelte3-ts-boilerplate",
-    "url": "https://github.com/tonyrewin/svelte3-ts-boilerplate"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Developer Experience",
     "description": "console.log()-like interactive inspector for Svelte 3",
     "image": "",
@@ -3454,18 +2723,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Template with TypeScript, Babel, Jest, Svelte-Testing-Library, Eslint, and Prettier",
-    "image": "",
-    "stars": 4,
-    "tags": [
-      "templates"
-    ],
-    "title": "will-wow/svelte-typescript-template",
-    "url": "https://github.com/will-wow/svelte-typescript-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "",
     "description": "CSS media queries in Svelte",
     "image": "",
@@ -3536,30 +2793,6 @@
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A base for building shareable Svelte 3 components",
-    "image": "",
-    "stars": 161,
-    "tags": [
-      "templates"
-    ],
-    "title": "YogliB/svelte-component-template",
-    "url": "https://github.com/YogliB/svelte-component-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "A base for building shareable Svelte 3 components.",
-    "image": "",
-    "stars": 161,
-    "tags": [
-      "templates"
-    ],
-    "title": "svelte-component-template",
-    "url": "https://github.com/YogliB/svelte-component-template"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
     "category": "Forms & User Input",
     "description": "A Svelte component wrapper around FullCalendar.",
     "image": "",
@@ -3571,18 +2804,6 @@
     ],
     "title": "svelte-fullcalendar",
     "url": "https://github.com/YogliB/svelte-fullcalendar"
-  },
-  {
-    "addedOn": "2020-09-29T14:39:13Z",
-    "category": "Boilerplate",
-    "description": "Skip setup and start code with SENT (Sapper.js, Express.js, Node.js, Typescript) and other tools template",
-    "image": "",
-    "stars": 55,
-    "tags": [
-      "templates"
-    ],
-    "title": "Zimtir/SENT-template",
-    "url": "https://github.com/Zimtir/SENT-template"
   },
   {
     "addedOn": "2020-09-29T14:39:13Z",


### PR DESCRIPTION
As described in https://github.com/svelte-society/sveltesociety.dev/issues/231, this moves the boilerplates out of components and onto their own page. Boilerplates aren't technically components and it also allows us to have multiple different boilerplate categories. It has categories for Svelte and Sapper. I'll add one for SvelteKit as a follow up. At that point we can archive https://github.com/sveltejs/integrations in favor of https://sveltesociety.dev/