### PR TITLE
Upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "~TODO~",
 			"version": "0.0.1",
 			"dependencies": {
-				"svelte-highlight": "^3.1.0"
+				"svelte-highlight": "^3.2.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "next",
@@ -42,9 +42,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-			"integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+			"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -224,18 +224,18 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
-			"version": "1.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.13.tgz",
-			"integrity": "sha512-zaXJlWK9JfrjrE6nG5etB8kf4DSkbE3H8Ql6gmCk3WjdvpY85a60TMYBU9OK2iunkqpHnPYiMUGEnOGYmWlLYA==",
+			"version": "1.0.0-next.16",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.16.tgz",
+			"integrity": "sha512-xGFcg+GHF0BL1fyWx2vCzlYj4S4R+Od9cF00soo1TVp/scGOi1G9grSYYW4x5H+iDn1sscoJ65OGBGWIcOgrXg==",
 			"dev": true
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.138",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.138.tgz",
-			"integrity": "sha512-ajJVravr/h0uWysyKyrdqOphNj1bgPZ7Ovgf6dv/L+ubE5LKA8ZgqqxgfmMHIwm9d66vcYU6TydaQOAGrlIGCA==",
+			"version": "1.0.0-next.150",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.150.tgz",
+			"integrity": "sha512-crIpEgy8dyKvaMrEYmNm38lTwcwEY0wv8+L672WhgvHVx4cmiKsGAocq73I2h3f4lnlxa1mBwi7jrNTZO1lUDg==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.14",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
 				"cheap-watch": "^1.0.3",
 				"sade": "^1.7.4",
 				"vite": "^2.4.3"
@@ -247,13 +247,13 @@
 				"node": "^12.20 || >=14.13"
 			},
 			"peerDependencies": {
-				"svelte": "^3.34.0"
+				"svelte": "^3.39.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.14",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.14.tgz",
-			"integrity": "sha512-46IKPtoGcdo6YLyUhvsXyC1Dg3m2HlbgreZqxM/h5DzavgUa75c/WHT5cIxxLppG+gxtct7V08/WNEdpFdmM3Q==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.17.tgz",
+			"integrity": "sha512-Xh/YYqBMDJnDheutnGHk/I5TO6w9gZ2GMgvG+qQm/gpIRkaTLts6Mw5xDe6cac/nH/aVPPVPibhq2pf26d44fA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -287,15 +287,15 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.8",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-			"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.4.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.6.tgz",
-			"integrity": "sha512-FKyawK3o5KL16AwbeFajen8G4K3mmqUrQsehn5wNKs8IzlKHE8TfnSmILXVMVziAEcnB23u1RCFU1NT6hSyr7Q==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+			"integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -326,13 +326,13 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.5.tgz",
-			"integrity": "sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
+			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "4.28.5",
-				"@typescript-eslint/scope-manager": "4.28.5",
+				"@typescript-eslint/experimental-utils": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.1",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -357,15 +357,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.5.tgz",
-			"integrity": "sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
+			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.28.5",
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/typescript-estree": "4.28.5",
+				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/typescript-estree": "4.29.1",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -381,14 +381,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.5.tgz",
-			"integrity": "sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
+			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "4.28.5",
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/typescript-estree": "4.28.5",
+				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/typescript-estree": "4.29.1",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -408,13 +408,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.5.tgz",
-			"integrity": "sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
+			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/visitor-keys": "4.28.5"
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/visitor-keys": "4.29.1"
 			},
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.5.tgz",
-			"integrity": "sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
+			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
 			"dev": true,
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -438,13 +438,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.5.tgz",
-			"integrity": "sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
+			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/visitor-keys": "4.28.5",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/visitor-keys": "4.29.1",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -465,12 +465,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.5.tgz",
-			"integrity": "sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
+			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.28.5",
+				"@typescript-eslint/types": "4.29.1",
 				"eslint-visitor-keys": "^2.0.0"
 			},
 			"engines": {
@@ -694,16 +694,16 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+			"version": "4.16.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
 			"dev": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001219",
+				"caniuse-lite": "^1.0.30001248",
 				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.723",
+				"electron-to-chromium": "^1.3.793",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"node-releases": "^1.1.73"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -756,9 +756,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001248",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-			"integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -766,9 +766,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-			"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -865,15 +865,15 @@
 			"dev": true
 		},
 		"node_modules/colord": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/colord/-/colord-2.4.0.tgz",
-			"integrity": "sha512-2306/NeTDOykDwvFQK0ctnP+9I5KQdqVm+IJAM6MsAr4vvy1llAdJyax4YmZoqTxdJ/lvRBwR8MqyJi/tupBAw==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
+			"integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q==",
 			"dev": true
 		},
 		"node_modules/colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+			"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
 			"dev": true
 		},
 		"node_modules/commander": {
@@ -1240,9 +1240,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.790",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.790.tgz",
-			"integrity": "sha512-epMH/S2MkhBv+Y0+nHK8dC7bzmOaPwcmiYqt+VwxSUJLgPzkqZnGUEQ8eVhy5zGmgWm9tDDdXkHDzOEsVU979A==",
+			"version": "1.3.806",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
+			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -1282,9 +1282,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.12.16",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.16.tgz",
-			"integrity": "sha512-XqI9cXP2bmQ6MREIqrYBb13KfYFSERsV1+e5jSVWps8dNlLZK+hln7d0mznzDIpfISsg/AgQW0DW3kSInXWhrg==",
+			"version": "0.12.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
+			"integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1313,9 +1313,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "7.31.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-			"integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "7.12.11",
@@ -1641,9 +1641,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-			"integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
 			"dev": true
 		},
 		"node_modules/fraction.js": {
@@ -1678,6 +1678,20 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -1724,9 +1738,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+			"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -1768,9 +1782,9 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
 			"dev": true
 		},
 		"node_modules/has": {
@@ -1801,9 +1815,9 @@
 			"dev": true
 		},
 		"node_modules/highlight.js": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
-			"integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+			"integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -2135,12 +2149,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.toarray": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-			"dev": true
-		},
 		"node_modules/lodash.topath": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
@@ -2278,9 +2286,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -2296,18 +2304,18 @@
 			"dev": true
 		},
 		"node_modules/node-emoji": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+			"integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
 			"dev": true,
 			"dependencies": {
-				"lodash.toarray": "^4.4.0"
+				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.73",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+			"version": "1.1.74",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
+			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
@@ -3218,9 +3226,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.55.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.55.0.tgz",
-			"integrity": "sha512-Atc3QqelKzrKwRkqnSdq0d2Mi8e0iGuL+kZebKMZ4ysyWHD5hw9VfVCAuODIW5837RENV8LXcbAEHurYf+ArvA==",
+			"version": "2.56.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
+			"integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -3459,20 +3467,20 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.41.0.tgz",
-			"integrity": "sha512-X9/lnTcRBCrMdyFBVjfmqy1T2vyN8ejUE1OfbWSccc2Z42Amn3ab3XdBgVl+oDkZvzPfPMoxo6CEbWca7pXOew==",
+			"version": "3.42.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
+			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-highlight": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-3.1.0.tgz",
-			"integrity": "sha512-4sPWRqbXSUOCOTH+exODx/JYo9KDN41B51wPfo522CZQ/SYEU76pOFrri/RHbVPA6i82lw8Un3VluJWKHehu1Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-3.2.0.tgz",
+			"integrity": "sha512-eI1zh+bqisIH/y07pLOrqhaaKna+dV3jB4yiFqAdAbUkgcSpaaGL4lSjxKqUnAd1/lZh7NN1AxurEUQ2GfK2UA==",
 			"dependencies": {
-				"highlight.js": "11.1.0"
+				"highlight.js": "11.2.0"
 			}
 		},
 		"node_modules/svelte-hmr": {
@@ -3549,13 +3557,13 @@
 			}
 		},
 		"node_modules/svgo": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
-			"integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.4.0.tgz",
+			"integrity": "sha512-W25S1UUm9Lm9VnE0TvCzL7aso/NCzDEaXLaElCUO/KaVitw0+IBicSVfM1L1c0YHK5TOFh73yQ2naCpVHEQ/OQ==",
 			"dev": true,
 			"dependencies": {
 				"@trysound/sax": "0.1.1",
-				"chalk": "^4.1.0",
+				"colorette": "^1.2.2",
 				"commander": "^7.1.0",
 				"css-select": "^4.1.3",
 				"css-tree": "^1.1.2",
@@ -3707,9 +3715,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
 			"dev": true
 		},
 		"node_modules/tsutils": {
@@ -3930,9 +3938,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-			"integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+			"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
 			"dev": true
 		},
 		"@babel/highlight": {
@@ -4075,27 +4083,27 @@
 			}
 		},
 		"@sveltejs/adapter-static": {
-			"version": "1.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.13.tgz",
-			"integrity": "sha512-zaXJlWK9JfrjrE6nG5etB8kf4DSkbE3H8Ql6gmCk3WjdvpY85a60TMYBU9OK2iunkqpHnPYiMUGEnOGYmWlLYA==",
+			"version": "1.0.0-next.16",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.16.tgz",
+			"integrity": "sha512-xGFcg+GHF0BL1fyWx2vCzlYj4S4R+Od9cF00soo1TVp/scGOi1G9grSYYW4x5H+iDn1sscoJ65OGBGWIcOgrXg==",
 			"dev": true
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.138",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.138.tgz",
-			"integrity": "sha512-ajJVravr/h0uWysyKyrdqOphNj1bgPZ7Ovgf6dv/L+ubE5LKA8ZgqqxgfmMHIwm9d66vcYU6TydaQOAGrlIGCA==",
+			"version": "1.0.0-next.150",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.150.tgz",
+			"integrity": "sha512-crIpEgy8dyKvaMrEYmNm38lTwcwEY0wv8+L672WhgvHVx4cmiKsGAocq73I2h3f4lnlxa1mBwi7jrNTZO1lUDg==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.14",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
 				"cheap-watch": "^1.0.3",
 				"sade": "^1.7.4",
 				"vite": "^2.4.3"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.14",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.14.tgz",
-			"integrity": "sha512-46IKPtoGcdo6YLyUhvsXyC1Dg3m2HlbgreZqxM/h5DzavgUa75c/WHT5cIxxLppG+gxtct7V08/WNEdpFdmM3Q==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.17.tgz",
+			"integrity": "sha512-Xh/YYqBMDJnDheutnGHk/I5TO6w9gZ2GMgvG+qQm/gpIRkaTLts6Mw5xDe6cac/nH/aVPPVPibhq2pf26d44fA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -4113,15 +4121,15 @@
 			"dev": true
 		},
 		"@types/json-schema": {
-			"version": "7.0.8",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-			"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.4.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.6.tgz",
-			"integrity": "sha512-FKyawK3o5KL16AwbeFajen8G4K3mmqUrQsehn5wNKs8IzlKHE8TfnSmILXVMVziAEcnB23u1RCFU1NT6hSyr7Q==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+			"integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -4152,13 +4160,13 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.5.tgz",
-			"integrity": "sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
+			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.28.5",
-				"@typescript-eslint/scope-manager": "4.28.5",
+				"@typescript-eslint/experimental-utils": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.1",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -4167,55 +4175,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.5.tgz",
-			"integrity": "sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
+			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.28.5",
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/typescript-estree": "4.28.5",
+				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/typescript-estree": "4.29.1",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.5.tgz",
-			"integrity": "sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
+			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.28.5",
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/typescript-estree": "4.28.5",
+				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/typescript-estree": "4.29.1",
 				"debug": "^4.3.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.5.tgz",
-			"integrity": "sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
+			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/visitor-keys": "4.28.5"
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/visitor-keys": "4.29.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.5.tgz",
-			"integrity": "sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
+			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.5.tgz",
-			"integrity": "sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
+			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.28.5",
-				"@typescript-eslint/visitor-keys": "4.28.5",
+				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/visitor-keys": "4.29.1",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -4224,12 +4232,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.5.tgz",
-			"integrity": "sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==",
+			"version": "4.29.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
+			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.28.5",
+				"@typescript-eslint/types": "4.29.1",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
@@ -4391,16 +4399,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+			"version": "4.16.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001219",
+				"caniuse-lite": "^1.0.30001248",
 				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.723",
+				"electron-to-chromium": "^1.3.793",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"node-releases": "^1.1.73"
 			}
 		},
 		"bytes": {
@@ -4434,15 +4442,15 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001248",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-			"integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-			"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -4524,15 +4532,15 @@
 			}
 		},
 		"colord": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/colord/-/colord-2.4.0.tgz",
-			"integrity": "sha512-2306/NeTDOykDwvFQK0ctnP+9I5KQdqVm+IJAM6MsAr4vvy1llAdJyax4YmZoqTxdJ/lvRBwR8MqyJi/tupBAw==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
+			"integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q==",
 			"dev": true
 		},
 		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+			"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
 			"dev": true
 		},
 		"commander": {
@@ -4798,9 +4806,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.790",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.790.tgz",
-			"integrity": "sha512-epMH/S2MkhBv+Y0+nHK8dC7bzmOaPwcmiYqt+VwxSUJLgPzkqZnGUEQ8eVhy5zGmgWm9tDDdXkHDzOEsVU979A==",
+			"version": "1.3.806",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
+			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -4834,9 +4842,9 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.12.16",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.16.tgz",
-			"integrity": "sha512-XqI9cXP2bmQ6MREIqrYBb13KfYFSERsV1+e5jSVWps8dNlLZK+hln7d0mznzDIpfISsg/AgQW0DW3kSInXWhrg==",
+			"version": "0.12.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
+			"integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
 			"dev": true
 		},
 		"escalade": {
@@ -4852,9 +4860,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.31.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-			"integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
@@ -5103,9 +5111,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-			"integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
 			"dev": true
 		},
 		"fraction.js": {
@@ -5130,6 +5138,13 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -5167,9 +5182,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+			"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
@@ -5198,9 +5213,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
 			"dev": true
 		},
 		"has": {
@@ -5225,9 +5240,9 @@
 			"dev": true
 		},
 		"highlight.js": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
-			"integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA=="
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+			"integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
 		},
 		"hsl-regex": {
 			"version": "1.0.0",
@@ -5498,12 +5513,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"lodash.toarray": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-			"dev": true
-		},
 		"lodash.topath": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
@@ -5614,9 +5623,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -5626,18 +5635,18 @@
 			"dev": true
 		},
 		"node-emoji": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+			"integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
 			"dev": true,
 			"requires": {
-				"lodash.toarray": "^4.4.0"
+				"lodash": "^4.17.21"
 			}
 		},
 		"node-releases": {
-			"version": "1.1.73",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+			"version": "1.1.74",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
+			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -6236,9 +6245,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.55.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.55.0.tgz",
-			"integrity": "sha512-Atc3QqelKzrKwRkqnSdq0d2Mi8e0iGuL+kZebKMZ4ysyWHD5hw9VfVCAuODIW5837RENV8LXcbAEHurYf+ArvA==",
+			"version": "2.56.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
+			"integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -6405,17 +6414,17 @@
 			}
 		},
 		"svelte": {
-			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.41.0.tgz",
-			"integrity": "sha512-X9/lnTcRBCrMdyFBVjfmqy1T2vyN8ejUE1OfbWSccc2Z42Amn3ab3XdBgVl+oDkZvzPfPMoxo6CEbWca7pXOew==",
+			"version": "3.42.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
+			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==",
 			"dev": true
 		},
 		"svelte-highlight": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-3.1.0.tgz",
-			"integrity": "sha512-4sPWRqbXSUOCOTH+exODx/JYo9KDN41B51wPfo522CZQ/SYEU76pOFrri/RHbVPA6i82lw8Un3VluJWKHehu1Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-3.2.0.tgz",
+			"integrity": "sha512-eI1zh+bqisIH/y07pLOrqhaaKna+dV3jB4yiFqAdAbUkgcSpaaGL4lSjxKqUnAd1/lZh7NN1AxurEUQ2GfK2UA==",
 			"requires": {
-				"highlight.js": "11.1.0"
+				"highlight.js": "11.2.0"
 			}
 		},
 		"svelte-hmr": {
@@ -6438,13 +6447,13 @@
 			}
 		},
 		"svgo": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
-			"integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.4.0.tgz",
+			"integrity": "sha512-W25S1UUm9Lm9VnE0TvCzL7aso/NCzDEaXLaElCUO/KaVitw0+IBicSVfM1L1c0YHK5TOFh73yQ2naCpVHEQ/OQ==",
 			"dev": true,
 			"requires": {
 				"@trysound/sax": "0.1.1",
-				"chalk": "^4.1.0",
+				"colorette": "^1.2.2",
 				"commander": "^7.1.0",
 				"css-select": "^4.1.3",
 				"css-tree": "^1.1.2",
@@ -6567,9 +6576,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
 			"dev": true
 		},
 		"tsutils": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"svelte-highlight": "^3.1.0"
+		"svelte-highlight": "^3.2.0"
 	}
 }


### PR DESCRIPTION
I'm hoping to eventually get rid of the `svelte-highlight` workaround we have in `svelte.config.js`. It will help me a bit to have the latest versions of stuff for testing