### PR TITLE
fix: fixes recipes overflowing when greater than 920px

### DIFF
--- a/src/routes/recipes/index.svelte
+++ b/src/routes/recipes/index.svelte
@@ -99,16 +99,21 @@
 		display: flex;
 		justify-content: center;
 	}
-
 	.categories-wrap {
 		display: grid;
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 		flex-wrap: wrap;
 		padding: 1rem;
 	}
-	@media screen and (max-width: 920px) {
+	@media screen and (max-width: 1024px) {
 		.categories-wrap {
-			grid-template-columns: auto;
+			grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+		}
+	}
+	@media screen and (max-width: 600px) {
+		.categories-wrap {
+
+			grid-template-columns: 1fr
 		}
 	}
 	.category-style {


### PR DESCRIPTION
At certain viewport sizes the list of recipes on the Recipes page would overflow the page (see below).

**Before**
<img width="1392" alt="Screenshot 2021-08-15 at 18 01 04" src="https://user-images.githubusercontent.com/4213219/129486406-f4227e47-d61f-4f38-b011-776edb336cbc.png">

**After**
<img width="1392" alt="Screenshot 2021-08-15 at 18 01 13" src="https://user-images.githubusercontent.com/4213219/129486407-6db50341-20bc-497d-bea7-08f5ff5d9e21.png">

To resolve this I have updated the styles for this page to match the `grid-template-columns` within the `CategoryTree` component. This may be a band-aid solution and it may be more robust for the `CategoryTree` styles to take up the maximum width of their container and then the parents define the available width, however, with this being my first contribution I wanted to keep the scope of the PR small.

Thanks :)