### PR TITLE
upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,21 +224,21 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
-			"version": "1.0.0-next.16",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.16.tgz",
-			"integrity": "sha512-xGFcg+GHF0BL1fyWx2vCzlYj4S4R+Od9cF00soo1TVp/scGOi1G9grSYYW4x5H+iDn1sscoJ65OGBGWIcOgrXg==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.17.tgz",
+			"integrity": "sha512-RKYNkQxtsMgt0wD8PhfXR1hGT1Tmq1E5eZeTr1KxIerczITRnWVT8LElfu/9Kusv44yYlyQtNc1mLoYqgloOQw==",
 			"dev": true
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.150",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.150.tgz",
-			"integrity": "sha512-crIpEgy8dyKvaMrEYmNm38lTwcwEY0wv8+L672WhgvHVx4cmiKsGAocq73I2h3f4lnlxa1mBwi7jrNTZO1lUDg==",
+			"version": "1.0.0-next.156",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.156.tgz",
+			"integrity": "sha512-YHT3sbPKpBGSYYFgEpXUx7JhN682wdXhc5INYZGqFfaGqkIOrThosz8qRsLQBfRbFnu0fzgWSsfj7FKq8YeFuA==",
 			"dev": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
 				"cheap-watch": "^1.0.3",
 				"sade": "^1.7.4",
-				"vite": "^2.4.3"
+				"vite": "^2.5.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -251,9 +251,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.17",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.17.tgz",
-			"integrity": "sha512-Xh/YYqBMDJnDheutnGHk/I5TO6w9gZ2GMgvG+qQm/gpIRkaTLts6Mw5xDe6cac/nH/aVPPVPibhq2pf26d44fA==",
+			"version": "1.0.0-next.19",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.19.tgz",
+			"integrity": "sha512-q9hHkMzodScwDq64pNaWhekpj97vWg3wO9T0rqd8bC2EsrBQs2uD1qMJvDqlNd63AbO2uSJMGo+TQ0Xt2xgyYg==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -293,9 +293,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-			"integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+			"version": "16.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+			"integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -326,13 +326,13 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz",
+			"integrity": "sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "4.29.1",
-				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/experimental-utils": "4.29.3",
+				"@typescript-eslint/scope-manager": "4.29.3",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -357,15 +357,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
+			"integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.3",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/typescript-estree": "4.29.3",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -381,14 +381,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.3.tgz",
+			"integrity": "sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.3",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/typescript-estree": "4.29.3",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -408,13 +408,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
+			"integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/visitor-keys": "4.29.3"
 			},
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
+			"integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
 			"dev": true,
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -438,13 +438,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
+			"integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/visitor-keys": "4.29.3",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -465,12 +465,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
+			"integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/types": "4.29.3",
 				"eslint-visitor-keys": "^2.0.0"
 			},
 			"engines": {
@@ -591,9 +591,9 @@
 			}
 		},
 		"node_modules/arg": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
-			"integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+			"integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
 			"dev": true
 		},
 		"node_modules/argparse": {
@@ -624,14 +624,14 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+			"integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
-				"colorette": "^1.2.2",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
@@ -694,16 +694,16 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.16.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
 			"dev": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001248",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.793",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.73"
+				"node-releases": "^1.1.75"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -892,9 +892,9 @@
 			"dev": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
@@ -1005,12 +1005,12 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.8.tgz",
+			"integrity": "sha512-Lda7geZU0Yu+RZi2SGpjYuQz4HI4/1Y+BhdD0jL7NXAQ5larCzVn+PUGuZbDMYz904AXXCOgO5L1teSvgu7aFg==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-preset-default": "^5.1.3",
+				"cssnano-preset-default": "^5.1.4",
 				"is-resolvable": "^1.1.0",
 				"lilconfig": "^2.0.3",
 				"yaml": "^1.10.2"
@@ -1027,9 +1027,9 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
-			"integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.4.tgz",
+			"integrity": "sha512-sPpQNDQBI3R/QsYxQvfB4mXeEcWuw0wGtKtmS5eg8wudyStYMgKOQT39G07EbW1LB56AOYrinRS9f0ig4Y3MhQ==",
 			"dev": true,
 			"dependencies": {
 				"css-declaration-sorter": "^6.0.3",
@@ -1044,7 +1044,7 @@
 				"postcss-merge-longhand": "^5.0.2",
 				"postcss-merge-rules": "^5.0.2",
 				"postcss-minify-font-values": "^5.0.1",
-				"postcss-minify-gradients": "^5.0.1",
+				"postcss-minify-gradients": "^5.0.2",
 				"postcss-minify-params": "^5.0.1",
 				"postcss-minify-selectors": "^5.1.0",
 				"postcss-normalize-charset": "^5.0.1",
@@ -1240,9 +1240,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.806",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==",
+			"version": "1.3.816",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.816.tgz",
+			"integrity": "sha512-/AvJPIJldO0NkwkfpUD7u1e4YEGRFBQpFuvl9oGCcVgWOObsZB1loxVGeVUJB9kmvfsBUUChPYdgRzx6+AKNyg==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -1282,9 +1282,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.12.20",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
-			"integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
+			"version": "0.12.22",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.22.tgz",
+			"integrity": "sha512-yWCr9RoFehpqoe/+MwZXJpYOEIt7KOEvNnjIeMZpMSyQt+KCBASM3y7yViiN5dJRphf1wGdUz1+M4rTtWd/ulA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1595,9 +1595,9 @@
 			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+			"integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1808,12 +1808,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"node_modules/highlight.js": {
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
@@ -1821,18 +1815,6 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
-		},
-		"node_modules/hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"node_modules/hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
 		},
 		"node_modules/html-tags": {
 			"version": "3.1.0",
@@ -1953,33 +1935,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"dependencies": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			}
-		},
-		"node_modules/is-color-stop/node_modules/css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -2313,9 +2272,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.74",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
@@ -2677,13 +2636,13 @@
 			}
 		},
 		"node_modules/postcss-minify-gradients": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz",
-			"integrity": "sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.2.tgz",
+			"integrity": "sha512-7Do9JP+wqSD6Prittitt2zDLrfzP9pqKs2EcLX7HJYxsxCOwrrcLt4x/ctQTsiOw+/8HYotAoqNkrzItL19SdQ==",
 			"dev": true,
 			"dependencies": {
+				"colord": "^2.6",
 				"cssnano-utils": "^2.0.1",
-				"is-color-stop": "^1.1.0",
 				"postcss-value-parser": "^4.1.0"
 			},
 			"engines": {
@@ -3198,18 +3157,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"node_modules/rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
-		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -3226,9 +3173,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.56.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-			"integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+			"version": "2.56.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+			"integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -3467,9 +3414,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.42.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
-			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==",
+			"version": "3.42.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.2.tgz",
+			"integrity": "sha512-FOyNYKXb8wdE0Ot+Ctt2/OyDLsNBP8+V6PUE9ag6ZKeLslIou0LnMu1fhtWUA+HjzKTbAM1yj+4PFLtg/3pMJA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
@@ -3493,9 +3440,9 @@
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.7.4.tgz",
-			"integrity": "sha512-mDAmaltQl6e5zU2VEtoWEf7eLTfuOTGr9zt+BpA3AGHo8MIhKiNSPE9OLTCTOMgj0vj/uL9QBbaNmpG4G1CgIA==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.8.0.tgz",
+			"integrity": "sha512-i9Z17cwGlp+kuSSv3kJWdAdAP2L26A5yMzHHdDj8YL+86sN64Yz5/gfjQp3Xb6fiaToo4sB+wTpid/23Gz0yvw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3852,12 +3799,12 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.4.4.tgz",
-			"integrity": "sha512-m1wK6pFJKmaYA6AeZIUXyiAgUAAJzVXhIMYCdZUpCaFMGps0v0IlNJtbmPvkUhVEyautalajmnW5X6NboUPsnw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.5.1.tgz",
+			"integrity": "sha512-FwmLbbz8MB1pBs9dKoRDgpiqoijif8hSK1+NNUYc12/cnf+pM2UFhhQ1rcpXgbMhm/5c2USZdVAf0FSkSxaFDA==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.12.8",
+				"esbuild": "^0.12.17",
 				"postcss": "^8.3.6",
 				"resolve": "^1.20.0",
 				"rollup": "^2.38.5"
@@ -3866,7 +3813,7 @@
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=12.2.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -4083,27 +4030,27 @@
 			}
 		},
 		"@sveltejs/adapter-static": {
-			"version": "1.0.0-next.16",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.16.tgz",
-			"integrity": "sha512-xGFcg+GHF0BL1fyWx2vCzlYj4S4R+Od9cF00soo1TVp/scGOi1G9grSYYW4x5H+iDn1sscoJ65OGBGWIcOgrXg==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.17.tgz",
+			"integrity": "sha512-RKYNkQxtsMgt0wD8PhfXR1hGT1Tmq1E5eZeTr1KxIerczITRnWVT8LElfu/9Kusv44yYlyQtNc1mLoYqgloOQw==",
 			"dev": true
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.150",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.150.tgz",
-			"integrity": "sha512-crIpEgy8dyKvaMrEYmNm38lTwcwEY0wv8+L672WhgvHVx4cmiKsGAocq73I2h3f4lnlxa1mBwi7jrNTZO1lUDg==",
+			"version": "1.0.0-next.156",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.156.tgz",
+			"integrity": "sha512-YHT3sbPKpBGSYYFgEpXUx7JhN682wdXhc5INYZGqFfaGqkIOrThosz8qRsLQBfRbFnu0fzgWSsfj7FKq8YeFuA==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
 				"cheap-watch": "^1.0.3",
 				"sade": "^1.7.4",
-				"vite": "^2.4.3"
+				"vite": "^2.5.0"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.17",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.17.tgz",
-			"integrity": "sha512-Xh/YYqBMDJnDheutnGHk/I5TO6w9gZ2GMgvG+qQm/gpIRkaTLts6Mw5xDe6cac/nH/aVPPVPibhq2pf26d44fA==",
+			"version": "1.0.0-next.19",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.19.tgz",
+			"integrity": "sha512-q9hHkMzodScwDq64pNaWhekpj97vWg3wO9T0rqd8bC2EsrBQs2uD1qMJvDqlNd63AbO2uSJMGo+TQ0Xt2xgyYg==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -4127,9 +4074,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-			"integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+			"version": "16.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+			"integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -4160,13 +4107,13 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz",
+			"integrity": "sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.29.1",
-				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/experimental-utils": "4.29.3",
+				"@typescript-eslint/scope-manager": "4.29.3",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -4175,55 +4122,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
+			"integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.3",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/typescript-estree": "4.29.3",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.3.tgz",
+			"integrity": "sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.3",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/typescript-estree": "4.29.3",
 				"debug": "^4.3.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
+			"integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/visitor-keys": "4.29.3"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
+			"integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
+			"integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
+				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/visitor-keys": "4.29.3",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -4232,12 +4179,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+			"version": "4.29.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
+			"integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/types": "4.29.3",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
@@ -4321,9 +4268,9 @@
 			}
 		},
 		"arg": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
-			"integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+			"integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
 			"dev": true
 		},
 		"argparse": {
@@ -4348,14 +4295,14 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+			"integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
-				"colorette": "^1.2.2",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
@@ -4399,16 +4346,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001248",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.793",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.73"
+				"node-releases": "^1.1.75"
 			}
 		},
 		"bytes": {
@@ -4556,9 +4503,9 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
 			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
@@ -4636,21 +4583,21 @@
 			"dev": true
 		},
 		"cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.8.tgz",
+			"integrity": "sha512-Lda7geZU0Yu+RZi2SGpjYuQz4HI4/1Y+BhdD0jL7NXAQ5larCzVn+PUGuZbDMYz904AXXCOgO5L1teSvgu7aFg==",
 			"dev": true,
 			"requires": {
-				"cssnano-preset-default": "^5.1.3",
+				"cssnano-preset-default": "^5.1.4",
 				"is-resolvable": "^1.1.0",
 				"lilconfig": "^2.0.3",
 				"yaml": "^1.10.2"
 			}
 		},
 		"cssnano-preset-default": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
-			"integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.4.tgz",
+			"integrity": "sha512-sPpQNDQBI3R/QsYxQvfB4mXeEcWuw0wGtKtmS5eg8wudyStYMgKOQT39G07EbW1LB56AOYrinRS9f0ig4Y3MhQ==",
 			"dev": true,
 			"requires": {
 				"css-declaration-sorter": "^6.0.3",
@@ -4665,7 +4612,7 @@
 				"postcss-merge-longhand": "^5.0.2",
 				"postcss-merge-rules": "^5.0.2",
 				"postcss-minify-font-values": "^5.0.1",
-				"postcss-minify-gradients": "^5.0.1",
+				"postcss-minify-gradients": "^5.0.2",
 				"postcss-minify-params": "^5.0.1",
 				"postcss-minify-selectors": "^5.1.0",
 				"postcss-normalize-charset": "^5.0.1",
@@ -4806,9 +4753,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.806",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==",
+			"version": "1.3.816",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.816.tgz",
+			"integrity": "sha512-/AvJPIJldO0NkwkfpUD7u1e4YEGRFBQpFuvl9oGCcVgWOObsZB1loxVGeVUJB9kmvfsBUUChPYdgRzx6+AKNyg==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -4842,9 +4789,9 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.12.20",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
-			"integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
+			"version": "0.12.22",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.22.tgz",
+			"integrity": "sha512-yWCr9RoFehpqoe/+MwZXJpYOEIt7KOEvNnjIeMZpMSyQt+KCBASM3y7yViiN5dJRphf1wGdUz1+M4rTtWd/ulA==",
 			"dev": true
 		},
 		"escalade": {
@@ -5074,9 +5021,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+			"integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -5233,28 +5180,10 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
-		"hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"highlight.js": {
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
 			"integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
-		},
-		"hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
 		},
 		"html-tags": {
 			"version": "3.1.0",
@@ -5347,32 +5276,10 @@
 				"binary-extensions": "^2.0.0"
 			}
 		},
-		"is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"requires": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			},
-			"dependencies": {
-				"css-color-names": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-					"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-					"dev": true
-				}
-			}
-		},
 		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -5644,9 +5551,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.74",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -5881,13 +5788,13 @@
 			}
 		},
 		"postcss-minify-gradients": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz",
-			"integrity": "sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.2.tgz",
+			"integrity": "sha512-7Do9JP+wqSD6Prittitt2zDLrfzP9pqKs2EcLX7HJYxsxCOwrrcLt4x/ctQTsiOw+/8HYotAoqNkrzItL19SdQ==",
 			"dev": true,
 			"requires": {
+				"colord": "^2.6",
 				"cssnano-utils": "^2.0.1",
-				"is-color-stop": "^1.1.0",
 				"postcss-value-parser": "^4.1.0"
 			}
 		},
@@ -6223,18 +6130,6 @@
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
-		"rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
-		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6245,9 +6140,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.56.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-			"integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+			"version": "2.56.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+			"integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -6414,9 +6309,9 @@
 			}
 		},
 		"svelte": {
-			"version": "3.42.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
-			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==",
+			"version": "3.42.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.2.tgz",
+			"integrity": "sha512-FOyNYKXb8wdE0Ot+Ctt2/OyDLsNBP8+V6PUE9ag6ZKeLslIou0LnMu1fhtWUA+HjzKTbAM1yj+4PFLtg/3pMJA==",
 			"dev": true
 		},
 		"svelte-highlight": {
@@ -6435,9 +6330,9 @@
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.7.4.tgz",
-			"integrity": "sha512-mDAmaltQl6e5zU2VEtoWEf7eLTfuOTGr9zt+BpA3AGHo8MIhKiNSPE9OLTCTOMgj0vj/uL9QBbaNmpG4G1CgIA==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.8.0.tgz",
+			"integrity": "sha512-i9Z17cwGlp+kuSSv3kJWdAdAP2L26A5yMzHHdDj8YL+86sN64Yz5/gfjQp3Xb6fiaToo4sB+wTpid/23Gz0yvw==",
 			"dev": true,
 			"requires": {
 				"@types/pug": "^2.0.4",
@@ -6678,12 +6573,12 @@
 			}
 		},
 		"vite": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.4.4.tgz",
-			"integrity": "sha512-m1wK6pFJKmaYA6AeZIUXyiAgUAAJzVXhIMYCdZUpCaFMGps0v0IlNJtbmPvkUhVEyautalajmnW5X6NboUPsnw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.5.1.tgz",
+			"integrity": "sha512-FwmLbbz8MB1pBs9dKoRDgpiqoijif8hSK1+NNUYc12/cnf+pM2UFhhQ1rcpXgbMhm/5c2USZdVAf0FSkSxaFDA==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.12.8",
+				"esbuild": "^0.12.17",
 				"fsevents": "~2.3.2",
 				"postcss": "^8.3.6",
 				"resolve": "^1.20.0",


### PR DESCRIPTION
Upgrade dependencies to pull in a new version of `@sveltejs/adapter-static`. This will make it so that output is cleared between builds, which will help @userquin's work on better supporting service workers