### PR TITLE
Fix: copy "npm install" command not working on firefox

### DIFF
--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -11,17 +11,15 @@
   export let repo = "";
 
   let clipboardCopy = false
-  const copyToClipboard = (text) => {
-    navigator.permissions.query({name: "clipboard-write"}).then(result => {
-      if (result.state == "granted" || result.state == "prompt") {
-        navigator.clipboard.writeText(text)
-        clipboardCopy = true
-        setTimeout(() => {
-          clipboardCopy = false
-        }, 1000)
-      }
-    }).catch(() => alert("Clipboard copy Permission denied"));
-  }
+	const copyToClipboard = (text) => {
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				clipboardCopy = true;
+				setTimeout(() => (clipboardCopy = false), 1000);
+			})
+			.catch(() => alert('Clipboard copy Permission denied'));
+	};
 </script>
 
 <style>


### PR DESCRIPTION
The `copyToClipboard` function fails on firefox and also expected to fail on safari because `clipboard-write` permission is not supported in the Permissions API as per [Clipboard - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#clipboard_availability) and [Permissions API - browser support](https://developer.mozilla.org/en-US/docs/Web/API/Permissions#browser_support).

As per MDN
> The "clipboard-write" permission of the Permissions API, is granted automatically to pages when they are in the active tab.

Using clipboard.writeText without a permission check works (tested on firefox 91 and edge 92).

Preview: https://deploy-preview-78--sveltesociety-preview.netlify.app/components/