### PR TITLE
fix: no stars print if undefined

### DIFF
--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -95,7 +95,7 @@
       <Tag title={tag} variant='blue' />
     {/each}
   </div>
-  {#if stars > 0}
+  {#if typeof stars !== 'undefined'}
     <div class="card__bottom">
       <div>
         {#if (repo || url).includes('github')}

--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -4,7 +4,7 @@
   export let title = "";
   export let description = "";
   export let tags = [];
-  export let stars = 0;
+  export let stars;
   export let addedOn = new Date();
   export let url = "";
   export let npm = "";

--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -95,22 +95,22 @@
       <Tag title={tag} variant='blue' />
     {/each}
   </div>
-  <div class="card__bottom">
-    <div>
-      {#if stars > 0}
+  {#if stars > 0}
+    <div class="card__bottom">
+      <div>
         {#if (repo || url).includes('github')}
           <img style="display:inline" src="/images/github_logo.svg" alt="github logo" />
         {:else if (repo || url).includes('gitlab')}
           <img style="display:inline" src="/images/gitlab_logo.svg" alt="gitlab logo" />
         <!-- {:else} -->
         {/if}
-      {/if}
+      </div>
+      <div>
+        &#9733;
+        <code>{stars}</code>
+      </div>
+      <!-- commenting out dates just cause it is not very updated yet - all the cards show same date. put back in when we have better scraping -->
+      <!-- <datetime value={addedOn}>{new Intl.DateTimeFormat('en-Us').format(Date.parse(addedOn))}</datetime> -->
     </div>
-    <div>
-      &#9733;
-      <code>{stars}</code>
-    </div>
-    <!-- commenting out dates just cause it is not very updated yet - all the cards show same date. put back in when we have better scraping -->
-    <!-- <datetime value={addedOn}>{new Intl.DateTimeFormat('en-Us').format(Date.parse(addedOn))}</datetime> -->
-  </div>
+  {/if}
 </div>


### PR DESCRIPTION
## Bug : 
1. go to https://sveltesociety.dev/components/
2. Sort by "Stars Asc"
3. See “undefined" as stars number

![image](https://user-images.githubusercontent.com/23191482/131403169-8ac37e24-ce79-48c5-b4c5-00a40a19d4c0.png)


The issue is there because the stars are secured to `0` only on the initialization : https://github.com/thollander/sveltesociety.dev/blob/0aee085e7428ca5ae60e6a5f0d3224779b3c7bc2/src/lib/components/ComponentIndex/Card.svelte#L7

## Fix : 
To fix this issue, I totally didn't print the section if we don't know the number of stars (not relevant to set 0, if we actually don't know). 