### PR TITLE
Add editorconfig + gitattribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[/src/**{.svelte,.js,.ts,.svx,.html,.json}]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+*                 text=auto
+*.html            text diff=html
+*.css             text
+*.js              text
+*.cjs             text
+*.json            text
+*.lock            text -diff
+package-lock.json text -diff
+*.svg             text
+*.*ignore         text
+*.svelte          text diff=html
+*.svx             text diff=markdown
+*.md              text diff=markdown
+*.svg             text
+*.woff2           binary
+*.*rc             text
+
+#
+# Exclude files from exporting
+#
+
+.editorconfig     export-ignore
+.eslintrc.cjs     export-ignore
+.gitattributes    export-ignore
+.github/          export-ignore
+.gitignore        export-ignore
+.gitpod.yml       export-ignore
+.npmrc            export-ignore
+.prettierignore   export-ignore
+.prettierrc       export-ignore
+jest.config.cjs   export-ignore


### PR DESCRIPTION
Editorconfig will help to preconfigure IDE with:
 - `tab` for indentation
 - `UTF-8` for file charset
 - Unix-style End of line

----

GitAttribute will help a bit in Github PR, and a do a little cleanup when exporting (download repo as zip)