### PR TITLE
Change url for community adapters

### DIFF
--- a/src/lib/components/ComponentIndex/CardList.svelte
+++ b/src/lib/components/ComponentIndex/CardList.svelte
@@ -1,6 +1,6 @@
 <script>
-	export let title,
-		id = `category-${encodeURI(title)}`;
+	export let title;
+	export let id = `category-${encodeURI(title)}`;
 </script>
 
 <div class="list">

--- a/src/lib/components/ComponentIndex/CardList.svelte
+++ b/src/lib/components/ComponentIndex/CardList.svelte
@@ -1,9 +1,10 @@
 <script>
-	export let title;
+	export let title,
+		id = `category-${encodeURI(title)}`;
 </script>
 
 <div class="list">
-	<h1 id="category-{encodeURI(title)}">{title} <a href="#category-{encodeURI(title)}">#</a></h1>
+	<h1 {id}>{title} <a href="#{id}">#</a></h1>
 	<div class="grid">
 		<slot />
 	</div>

--- a/src/routes/components/index.svelte
+++ b/src/routes/components/index.svelte
@@ -46,6 +46,8 @@
 		.sort(compare(sorting));
 	$: categories = extractUnique(dataToDisplay, 'category');
 	$: filterTag = selectedTags?.map((obj) => obj.value) || [];
+
+	const categoryId = { 'SvelteKit Adapters': 'adapters' };
 </script>
 
 <svelte:head>
@@ -100,7 +102,10 @@
 	</section>
 	<section slot="items">
 		{#each categories as category}
-			<List title={category.label || 'Unclassified'}>
+			<List
+				title={category.label || 'Unclassified'}
+				id={categoryId[category.label] || category.label}
+			>
 				{#each dataToDisplay.filter((d) => d.category === category.value) as data}
 					<ComponentCard {...data} manager={$packageManager} />
 				{/each}

--- a/src/routes/components/index.svelte
+++ b/src/routes/components/index.svelte
@@ -47,7 +47,22 @@
 	$: categories = extractUnique(dataToDisplay, 'category');
 	$: filterTag = selectedTags?.map((obj) => obj.value) || [];
 
-	const categoryId = { 'SvelteKit Adapters': 'adapters' };
+	const categoryId = {
+		Animations: 'animations',
+		'Data Visualisation': 'data-vis',
+		'Design Pattern': 'design-patterns',
+		'Design System': 'design-systems',
+		'Developer Experience': 'dx',
+		'Forms & User Input': 'input',
+		Integration: 'integrations',
+		'Rich Text Editor': 'text-editors',
+		Routers: 'routers',
+		Stores: 'stores',
+		'SvelteKit Adapters': 'adapters',
+		Testing: 'testing',
+		Unclassified: 'unclassified',
+		'User Interaction': 'ui'
+	};
 </script>
 
 <svelte:head>
@@ -104,7 +119,7 @@
 		{#each categories as category}
 			<List
 				title={category.label || 'Unclassified'}
-				id={categoryId[category.label] || category.label}
+				id={categoryId[category.label || 'Unclassified'] || category.label}
 			>
 				{#each dataToDisplay.filter((d) => d.category === category.value) as data}
 					<ComponentCard {...data} manager={$packageManager} />


### PR DESCRIPTION
Updated the url for sveltekit adapters from 
https://sveltesociety.dev/components#category-SvelteKit%20Adapters 
to
 https://sveltesociety.dev/components#adapters

A shorter nicer url is needed to show after initializing the app with create-svelte.
Related comment on kit https://github.com/sveltejs/kit/pull/2479#discussion_r714841927