### PR TITLE
cheatsheet: Use svelte syntax in style attribute

### DIFF
--- a/src/routes/cheatsheet/cheat-sheet.js
+++ b/src/routes/cheatsheet/cheat-sheet.js
@@ -67,12 +67,12 @@ export const cheatSheet = [
     export let color = ''
 </script>
 
-<a href={href} style={\`color: \${color}\`} >
+<a href={href} style="color: {color}" >
   {title}
 </a>
 
 // Shorthand
-<a {href} style={\`color: \${color}\`} >
+<a {href} style="color: {color}" >
   {title}
 </a>
 


### PR DESCRIPTION
Use svelte syntax as it is shorter and more efficient when using multiple style rules.
[Explained by pngwn on discord](https://discord.com/channels/457912077277855764/728292755087818924/902850756590329876)