### PR TITLE
Fix/title client update

### DIFF
--- a/src/lib/layouts/EventPage.svelte
+++ b/src/lib/layouts/EventPage.svelte
@@ -1,5 +1,8 @@
 <script>
+	import metatags from '$lib/stores/metatags';
+
 	export let title = '';
+	metatags.title(title);
 </script>
 
 <div>

--- a/src/lib/layouts/EventPage.svelte
+++ b/src/lib/layouts/EventPage.svelte
@@ -2,7 +2,7 @@
 	import metatags from '$lib/stores/metatags';
 
 	export let title = '';
-	metatags.title(title);
+	metatags.update({ title });
 </script>
 
 <div>

--- a/src/lib/layouts/Recipe.svelte
+++ b/src/lib/layouts/Recipe.svelte
@@ -6,7 +6,7 @@
 	import metatags from '$lib/stores/metatags';
 	export let title;
 
-	metatags.title(title);
+	metatags.update({ title });
 </script>
 
 <main>

--- a/src/lib/layouts/Recipe.svelte
+++ b/src/lib/layouts/Recipe.svelte
@@ -3,8 +3,10 @@
 	import Icon from '$lib/components/Icon/index.svelte';
 	import { categories } from '$lib/stores/recipes';
 	import { page } from '$app/stores';
-
+	import metatags from '$lib/stores/metatags';
 	export let title;
+
+	metatags.title(title);
 </script>
 
 <main>

--- a/src/lib/layouts/RecipeCategory.svelte
+++ b/src/lib/layouts/RecipeCategory.svelte
@@ -2,10 +2,13 @@
 	import Icon from '$lib/components/Icon/index.svelte';
 	import { categories } from '$lib/stores/recipes';
 	import { page } from '$app/stores';
+	import metatags from '$lib/stores/metatags';
 
 	const childrenNodes = $categories.find((c) => c.path === $page.path).children || [];
 
 	export let title;
+
+	metatags.title(title);
 </script>
 
 <main>

--- a/src/lib/layouts/RecipeCategory.svelte
+++ b/src/lib/layouts/RecipeCategory.svelte
@@ -8,7 +8,7 @@
 
 	export let title;
 
-	metatags.title(title);
+	metatags.update({ title });
 </script>
 
 <main>

--- a/src/lib/stores/metatags.ts
+++ b/src/lib/stores/metatags.ts
@@ -20,6 +20,10 @@ type Metatags = {
 	'og:url': string;
 };
 
+type UpdateMetaTags = Partial<
+	Pick<Metatags, 'title' | 'description' | 'type' | 'image' | 'alt'> & { url: string }
+>;
+
 const initialTags: Metatags = {
 	title: 'Svelte Society',
 	description:
@@ -53,27 +57,44 @@ type MetaTagsStore = {
 	image: (image: string) => void;
 	alt: (alt: string) => void;
 	url: (url: string) => void;
-	reset: () => void;
+	update: (opts: UpdateMetaTags) => void;
 };
 
 function CreateMetatagsStore(): MetaTagsStore {
 	const { subscribe, set, update } = writable(initialTags);
 
-	const title = (title) =>
-		update((curr) => ({ ...curr, title: title, 'og:title': title, 'twitter:title': title }));
-	const desc = (desc) =>
-		update((curr) => ({
-			...curr,
-			description: desc,
-			'og:description': desc,
-			'twitter:description': desc
-		}));
-	const image = (image) =>
-		update((curr) => ({ ...curr, image: image, 'og:image': image, 'twitter:image': image }));
-	const alt = (alt) =>
-		update((curr) => ({ ...curr, alt: alt, 'og:image:alt': alt, 'twitter:image:alt': alt }));
-	const url = (url) => update((curr) => ({ ...curr, 'og:url': url }));
-	const reset = () => set(initialTags);
+	const getTitles = (title: string) => ({ title, 'og:title': title, 'twitter:title': title });
+	const getDescriptions = (desc: string) => ({
+		description: desc,
+		'og:description': desc,
+		'twitter:description': desc
+	});
+	const getImages = (image: string) => ({ image, 'og:image': image, 'twitter:image': image });
+	const getAlts = (alt: string) => ({ alt, 'og:image:alt': alt, 'twitter:image:alt': alt });
+	const getUrls = (url: string) => ({ 'og:url': url });
+
+	const title = (title: string) => update((curr) => ({ ...curr, ...getTitles(title) }));
+	const desc = (desc: string) => update((curr) => ({ ...curr, ...getDescriptions(desc) }));
+	const image = (image: string) => update((curr) => ({ ...curr, ...getImages(image) }));
+	const alt = (alt: string) => update((curr) => ({ ...curr, ...getAlts(alt) }));
+	const url = (url: string) => update((curr) => ({ ...curr, ...getUrls(url) }));
+
+	const setUpdate = (opts: UpdateMetaTags) => {
+		const titles = opts.title ? getTitles(opts.title) : {};
+		const descriptions = opts.description ? getDescriptions(opts.description) : {};
+		const images = opts.image ? getImages(opts.image) : {};
+		const alts = opts.alt ? getAlts(opts.alt) : {};
+		const urls = opts.url ? getUrls(opts.url) : {};
+
+		set({
+			...initialTags,
+			...titles,
+			...descriptions,
+			...images,
+			...alts,
+			...urls
+		});
+	};
 
 	return {
 		subscribe,
@@ -83,7 +104,7 @@ function CreateMetatagsStore(): MetaTagsStore {
 		desc,
 		image,
 		alt,
-		reset
+		update: setUpdate
 	};
 }
 

--- a/src/lib/stores/metatags.ts
+++ b/src/lib/stores/metatags.ts
@@ -53,6 +53,7 @@ type MetaTagsStore = {
 	image: (image: string) => void;
 	alt: (alt: string) => void;
 	url: (url: string) => void;
+	reset: () => void;
 };
 
 function CreateMetatagsStore(): MetaTagsStore {
@@ -72,6 +73,7 @@ function CreateMetatagsStore(): MetaTagsStore {
 	const alt = (alt) =>
 		update((curr) => ({ ...curr, alt: alt, 'og:image:alt': alt, 'twitter:image:alt': alt }));
 	const url = (url) => update((curr) => ({ ...curr, 'og:url': url }));
+	const reset = () => set(initialTags);
 
 	return {
 		subscribe,
@@ -80,7 +82,8 @@ function CreateMetatagsStore(): MetaTagsStore {
 		title,
 		desc,
 		image,
-		alt
+		alt,
+		reset
 	};
 }
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -12,7 +12,6 @@
 	// as metadata set on one page can find its self on another
 	// page.
 	navigating.subscribe((res) => {
-		console.log(res);
 		if (res) {
 			metatags.reset();
 		} else {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,19 +6,6 @@
 	import Header from '$layout/Header.svelte';
 	import Footer from '$layout/Footer.svelte';
 	import metatags from '$lib/stores/metatags';
-	import { page, navigating } from '$app/stores';
-
-	// We need to reset our metadata on each navigation
-	// as metadata set on one page can find its self on another
-	// page.
-	navigating.subscribe((res) => {
-		if (res) {
-			metatags.reset();
-		} else {
-			// update our URL meta on page transitions
-			metatags.url($page.host + $page.path);
-		}
-	});
 </script>
 
 <svelte:head>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,6 +6,10 @@
 	import Header from '$layout/Header.svelte';
 	import Footer from '$layout/Footer.svelte';
 	import metatags from '$lib/stores/metatags';
+	import { page } from '$app/stores';
+
+	// update our URL meta on page transitions
+	page.subscribe(() => metatags.url($page.host + $page.path));
 </script>
 
 <svelte:head>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,10 +6,20 @@
 	import Header from '$layout/Header.svelte';
 	import Footer from '$layout/Footer.svelte';
 	import metatags from '$lib/stores/metatags';
-	import { page } from '$app/stores';
+	import { page, navigating } from '$app/stores';
 
-	// update our URL meta on page transitions
-	page.subscribe(() => metatags.url($page.host + $page.path));
+	// We need to reset our metadata on each navigation
+	// as metadata set on one page can find its self on another
+	// page.
+	navigating.subscribe((res) => {
+		console.log(res);
+		if (res) {
+			metatags.reset();
+		} else {
+			// update our URL meta on page transitions
+			metatags.url($page.host + $page.path);
+		}
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,19 +6,16 @@
 	import Header from '$layout/Header.svelte';
 	import Footer from '$layout/Footer.svelte';
 	import metatags from '$lib/stores/metatags';
-	import { page } from '$app/stores';
-
-	let path = $page.path.split('/').toString().replace(',', '');
-	if ($page.path === '/') path = 'Home';
-	const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
 </script>
 
 <svelte:head>
 	{#each Object.entries($metatags) as [property, content]}
 		{#if content}
-			{#if ['title', 'description', 'image'].includes(property)}
+			{#if property === 'title'}
+				<title>{content} - Svelte Society</title>
+				<meta name={property} content={`${content} - Svelte Society`} />
+			{:else if ['description', 'image'].includes(property)}
 				<meta name={property} {content} />
-				<title>{capitalize(path)} - Svelte Society</title>
 			{:else}
 				<meta {property} {content} />
 			{/if}

--- a/src/routes/about/__layout.svelte
+++ b/src/routes/about/__layout.svelte
@@ -1,6 +1,9 @@
-<svelte:head>
-	<title>About - Svelte Society</title>
-</svelte:head>
+<script>
+	import metatags from '$lib/stores/metatags';
+
+	metatags.title('About');
+</script>
+
 <main class="wrapper">
 	<slot />
 </main>

--- a/src/routes/about/__layout.svelte
+++ b/src/routes/about/__layout.svelte
@@ -1,7 +1,7 @@
 <script>
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('About');
+	metatags.update({ title: 'About' });
 </script>
 
 <main class="wrapper">

--- a/src/routes/cheatsheet/index.svelte
+++ b/src/routes/cheatsheet/index.svelte
@@ -1,12 +1,10 @@
 <script>
 	import CheatSheetCard from './_CheatSheetCard.svelte';
-	import { page } from '$app/stores';
 	import { cheatSheet } from './cheat-sheet';
 	import metatags from '$lib/stores/metatags';
 
 	metatags.title('Cheat Sheet');
 	metatags.desc('No time to read the docs? Just use the cheat sheet! :)');
-	metatags.url($page.host + $page.path);
 </script>
 
 <h1>Cheat Sheet</h1>

--- a/src/routes/cheatsheet/index.svelte
+++ b/src/routes/cheatsheet/index.svelte
@@ -3,8 +3,10 @@
 	import { cheatSheet } from './cheat-sheet';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Cheat Sheet');
-	metatags.desc('No time to read the docs? Just use the cheat sheet! :)');
+	metatags.update({
+		title: 'Cheat Sheet',
+		description: 'No time to read the docs? Just use the cheat sheet! :)'
+	});
 </script>
 
 <h1>Cheat Sheet</h1>

--- a/src/routes/cheatsheet/index.svelte
+++ b/src/routes/cheatsheet/index.svelte
@@ -4,7 +4,7 @@
 	import { cheatSheet } from './cheat-sheet';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Svelte Society - Cheat Sheet.');
+	metatags.title('Cheat Sheet');
 	metatags.desc('No time to read the docs? Just use the cheat sheet! :)');
 	metatags.url($page.host + $page.path);
 </script>

--- a/src/routes/components/index.svelte
+++ b/src/routes/components/index.svelte
@@ -9,6 +9,10 @@
 	import { compare, selectSortItems } from '$lib/utils/sort';
 	import { extractUnique } from '$lib/utils/extractUnique';
 	import Select from '$components/Select.svelte';
+	import metatags from '$lib/stores/metatags';
+
+	metatags.title('Components');
+
 	let searchValue;
 	const tagItems = extractUnique(components, 'tags');
 	let filterTag = [];

--- a/src/routes/components/index.svelte
+++ b/src/routes/components/index.svelte
@@ -11,7 +11,7 @@
 	import Select from '$components/Select.svelte';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Components');
+	metatags.update({ title: 'Components' });
 
 	let searchValue;
 	const tagItems = extractUnique(components, 'tags');

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -14,6 +14,9 @@
 <script lang="ts">
 	import Societies from '$lib/components/Societies/index.svelte';
 	import EventListElement from '$lib/components/EventListElement/index.svelte';
+	import metatags from '$lib/stores/metatags';
+
+	metatags.title('Events');
 	export let events = {};
 </script>
 

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -16,7 +16,7 @@
 	import EventListElement from '$lib/components/EventListElement/index.svelte';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Events');
+	metatags.update({ title: 'Events' });
 	export let events = {};
 </script>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,11 +1,9 @@
 <script>
 	import Link from '$layout/Link.svelte';
-	import { page } from '$app/stores';
 	import metatags from '$lib/stores/metatags';
 
 	metatags.title('Home');
 	metatags.desc('Svelte Society is a community-driven effort to organise and promote SvelteJS.');
-	metatags.url($page.host + $page.path);
 </script>
 
 <article class="container">

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Svelte Society - a community for Svelte users around the world.');
+	metatags.title('Home');
 	metatags.desc('Svelte Society is a community-driven effort to organise and promote SvelteJS.');
 	metatags.url($page.host + $page.path);
 </script>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -2,8 +2,10 @@
 	import Link from '$layout/Link.svelte';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Home');
-	metatags.desc('Svelte Society is a community-driven effort to organise and promote SvelteJS.');
+	metatags.update({
+		title: 'Home',
+		description: 'Svelte Society is a community-driven effort to organise and promote SvelteJS.'
+	});
 </script>
 
 <article class="container">

--- a/src/routes/recipes/index.svelte
+++ b/src/routes/recipes/index.svelte
@@ -9,7 +9,6 @@
 	metatags.desc(
 		'This cookbook serves shows users how best-in-practice code is written in Svelte. You’ll learn how to import third-party libraries, external scripts as well as how to handle common problems that you will have to solve often.'
 	);
-	metatags.url($page.host + $page.path);
 </script>
 
 <article>

--- a/src/routes/recipes/index.svelte
+++ b/src/routes/recipes/index.svelte
@@ -5,10 +5,11 @@
 	import { categories } from '$lib/stores/recipes';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Recipes');
-	metatags.desc(
-		'This cookbook serves shows users how best-in-practice code is written in Svelte. You’ll learn how to import third-party libraries, external scripts as well as how to handle common problems that you will have to solve often.'
-	);
+	metatags.update({
+		title: 'Recipes',
+		description:
+			'This cookbook serves shows users how best-in-practice code is written in Svelte. You’ll learn how to import third-party libraries, external scripts as well as how to handle common problems that you will have to solve often.'
+	});
 </script>
 
 <article>

--- a/src/routes/recipes/index.svelte
+++ b/src/routes/recipes/index.svelte
@@ -5,18 +5,12 @@
 	import { categories } from '$lib/stores/recipes';
 	import metatags from '$lib/stores/metatags';
 
-	let title = 'Recipes - Svelte Society';
-
-	metatags.title(title);
+	metatags.title('Recipes');
 	metatags.desc(
 		'This cookbook serves shows users how best-in-practice code is written in Svelte. You’ll learn how to import third-party libraries, external scripts as well as how to handle common problems that you will have to solve often.'
 	);
 	metatags.url($page.host + $page.path);
 </script>
-
-<svelte:head>
-	<title>{title}</title>
-</svelte:head>
 
 <article>
 	<h1>Cookbook</h1>

--- a/src/routes/templates/index.svelte
+++ b/src/routes/templates/index.svelte
@@ -6,6 +6,9 @@
 	import { extractUnique } from '$lib/utils/extractUnique';
 	import Select from '$lib/components/Select.svelte';
 	import SearchLayout from '$lib/layouts/SearchLayout.svelte';
+	import metatags from '$lib/stores/metatags';
+
+	metatags.title('Templates');
 
 	let searchValue;
 

--- a/src/routes/templates/index.svelte
+++ b/src/routes/templates/index.svelte
@@ -8,7 +8,7 @@
 	import SearchLayout from '$lib/layouts/SearchLayout.svelte';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Templates');
+	metatags.update({ title: 'Templates' });
 
 	let searchValue;
 

--- a/src/routes/tools/index.svelte
+++ b/src/routes/tools/index.svelte
@@ -7,6 +7,9 @@
 	import { extractUnique } from '$lib/utils/extractUnique';
 	import { compare, selectSortItems } from '$lib/utils/sort';
 	import components from '../templates/templates.json';
+	import metatags from '$lib/stores/metatags';
+
+	metatags.title('Tools');
 
 	let searchValue;
 

--- a/src/routes/tools/index.svelte
+++ b/src/routes/tools/index.svelte
@@ -9,7 +9,7 @@
 	import components from '../templates/templates.json';
 	import metatags from '$lib/stores/metatags';
 
-	metatags.title('Tools');
+	metatags.update({ title: 'Tools' });
 
 	let searchValue;
 


### PR DESCRIPTION
- Add consistent title format for all pages: `Title - Svelte Society`
- Fix issue where client page change did not update the page title
- Add human-friendly title to sub-pages of sections like: events and recipes
- Fix issue where previously set metadata can leak onto other pages
- Avoid setting `og:url` for now as its `undefiend` on SSR. -  the fallback uses a valid link