### PR TITLE
issue #163

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+name: JSON Format
+
+on:
+  pull_request_target:
+    branches: [format]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+    
+    - name: Prettify code
+      uses: creyD/prettier_action@v4.0
+      with:
+        prettier_options: --write **/*.json
+        only_changed: True

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,3 +19,5 @@ jobs:
       with:
         prettier_options: --write **/*.json
         only_changed: True
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v7

--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -2345,7 +2345,7 @@
 		"npm": "svelte-fsm",
 		"addedOn": "2021-11-01",
 		"category": "Stores",
-		"tags": ["in-page navigation","stores and state"],
+		"tags": ["in-page navigation", "stores and state"],
 		"stars": 1
 	}
 ]

--- a/src/routes/help/submitting.svelte
+++ b/src/routes/help/submitting.svelte
@@ -30,7 +30,7 @@
 
 	let clipboardCopy = false;
 	const copy = () => {
-		copyToClipboard(JSON.stringify(jsonSnippet, null, 4)).then(() => (clipboardCopy = false));
+		copyToClipboard(JSON.stringify(jsonSnippet, null, '\t')).then(() => (clipboardCopy = false));
 		clipboardCopy = true;
 	};
 
@@ -171,7 +171,7 @@
 
 <h2>JSON Snippet</h2>
 <pre>
-	{JSON.stringify(jsonSnippet,null,4)}<button on:click={copy}>{clipboardCopy ? 'Copied' : 'Copy'}</button>
+	{JSON.stringify(jsonSnippet,null,'\t')}<button on:click={copy}>{clipboardCopy ? 'Copied' : 'Copy'}</button>
 </pre>
 <br />
 Copy this snippet and add it to
@@ -246,6 +246,7 @@ propose your changes
 
 	pre {
 		position: relative;
+		tab-size: 4;
 	}
 
 	pre button {


### PR DESCRIPTION
Changes the json snippet to use tabs instead of spaces, and updates the styling on the pre tag so it looks the same as before (\t was indented 8 spaces without the style change).

This doesn't handle formatting the tags array because the correct formating is driven by prettier and depends on the length of the array. I think the best way to handle this is to add a formatting job to the github actions that runs before the linter. I can add that action with this pull request as well if desired.