### PR TITLE
Fix typo on cheatsheet

### DIFF
--- a/src/routes/cheatsheet/cheat-sheet.js
+++ b/src/routes/cheatsheet/cheat-sheet.js
@@ -357,7 +357,7 @@ import { onMount } from 'svelte'
 
 onMount(() => {
   console.log('Mounting')
-  return () => (consolo.log('going out'))
+  return () => console.log('going out')
 })
 </script>
 


### PR DESCRIPTION
Fixing a minor typo that I found on the cheatsheet.

I also removed the `()` around the `console.log`. AFAIK they shouldn't make a difference.