### PR TITLE
Add CMSvelte

### DIFF
--- a/src/routes/templates/templates.json
+++ b/src/routes/templates/templates.json
@@ -1,16 +1,13 @@
 [
 	{
-	    "title": "CMSvelte",
-	    "url": "https://github.com/sawyerclick/CMSvelte",
-	    "description": "A Svelte template built with newsroom CMS's in mind",
-	    "npm": "",
-	    "addedOn": "2022-02-27",
-	    "category": "Svelte",
-	    "tags": [
-		"templates",
-		"blog"
-	    ],
-	    "stars": 0
+		"title": "CMSvelte",
+		"url": "https://github.com/sawyerclick/CMSvelte",
+		"description": "A Svelte template built with newsroom CMS's in mind",
+		"npm": "",
+		"addedOn": "2022-02-27",
+		"category": "Svelte",
+		"tags": ["templates", "blog"],
+		"stars": 0
 	},
 	{
 		"addedOn": "2020-09-29T14:39:13Z",

--- a/src/routes/templates/templates.json
+++ b/src/routes/templates/templates.json
@@ -1,5 +1,18 @@
 [
 	{
+	    "title": "CMSvelte",
+	    "url": "https://github.com/sawyerclick/CMSvelte",
+	    "description": "A Svelte template built with newsroom CMS's in mind",
+	    "npm": "",
+	    "addedOn": "2022-02-27",
+	    "category": "Svelte",
+	    "tags": [
+		"templates",
+		"blog"
+	    ],
+	    "stars": 0
+	},
+	{
 		"addedOn": "2020-09-29T14:39:13Z",
 		"category": "Svelte",
 		"description": "Boilerplate with TypeScript, Webpack, Storybook, Travis CI, SCSS, Babel, EsLint, Prettier, Jest",


### PR DESCRIPTION
Add CMSvelte to the templates page. CMSvelte is a Svelte starter built for newsroom CMS's in mind. It features a scaled-back output file that allows for the embedding of charts wherever editors want them, and letting them move it around without breaking things.