### PR TITLE
Add lib svelte-lazy-loader to components

### DIFF
--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -1,5 +1,17 @@
 [
 	{
+	    "title": "svelte-lazy-loader",
+	    "url": "https://github.com/sawyerclick/svelte-lazy-loader",
+	    "description": "A lazy-loader component library for Svelte",
+	    "npm": "svelte-lazy-loader",
+	    "addedOn": "2022-02-27",
+	    "tags": [
+		"images",
+		"components and libraries"
+	    ],
+	    "stars": 0
+	}
+	{
 		"title": "svelte-carbonbadge",
 		"url": "https://gitlab.com/davidhund/svelte-carbonbadge",
 		"description": "Svelte badge component for https://www.websitecarbon.com/",

--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -10,7 +10,7 @@
 		"components and libraries"
 	    ],
 	    "stars": 0
-	}
+	},
 	{
 		"title": "svelte-carbonbadge",
 		"url": "https://gitlab.com/davidhund/svelte-carbonbadge",

--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -1,15 +1,12 @@
 [
 	{
-	    "title": "svelte-lazy-loader",
-	    "url": "https://github.com/sawyerclick/svelte-lazy-loader",
-	    "description": "A lazy-loader component library for Svelte",
-	    "npm": "svelte-lazy-loader",
-	    "addedOn": "2022-02-27",
-	    "tags": [
-		"images",
-		"components and libraries"
-	    ],
-	    "stars": 0
+		"title": "svelte-lazy-loader",
+		"url": "https://github.com/sawyerclick/svelte-lazy-loader",
+		"description": "A lazy-loader component library for Svelte",
+		"npm": "svelte-lazy-loader",
+		"addedOn": "2022-02-27",
+		"tags": ["images", "components and libraries"],
+		"stars": 0
 	},
 	{
 		"title": "svelte-carbonbadge",


### PR DESCRIPTION
Add svelte-lazy-loader to the components page. It's a library built with SvelteKit that, if native lazy-loading isn't supported by the browser, uses a shared IntersectionObserver instance to load images. The API is identical to HTLMImageElement. More components are forthcoming in the library as well.