### PR TITLE
Combine Uncategorized categories

### DIFF
--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -2384,6 +2384,7 @@
 		"description": "I18n library for Svelte.js that analyzes your keys at build time for max performance and minimal footprint",
 		"npm": "https://www.npmjs.com/package/svelte-intl-precompile",
 		"addedOn": "2022-01-09",
+		"category": "",
 		"tags": ["internationalization"],
 		"stars": 176
 	},


### PR DESCRIPTION
There are two categories that are `Uncategorized` because empty string and undefined are handled differently. This makes the missing one an empty string like the rest