### PR TITLE
fix: #if tags before #each

### DIFF
--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -42,11 +42,13 @@
 			/>{/if}
 	</h3>
 	<p class="flex-grow">{description}</p>
-	<div class="card__tags">
-		{#each tags as tag}
-			<Tag title={tag} variant="blue" />
-		{/each}
-	</div>
+	{#if tags}
+		<div class="card__tags">
+			{#each tags as tag}
+				<Tag title={tag} variant="blue" />
+			{/each}
+		</div>
+	{/if}
 	{#if typeof stars !== 'undefined'}
 		<div class="card__bottom">
 			<div>


### PR DESCRIPTION
Fixes https://github.com/svelte-society/sveltesociety.dev/issues/262

When you reproduce this issue in the dev server, the error is:
> index.mjs:2048 Uncaught (in promise) Error: {#each} only iterates over array-like objects.
>     at validate_each_argument (index.mjs:2048:15)
>     at Object.update [as p] (Card.svelte? [sm]:46:15)
>     at update (index.mjs:1085:36)
>     at flush (index.mjs:1052:13)

https://sveltesociety.dev/templates/ doesn't have this bug, /components/ & /tools/ do [edit: but all three use the same component this PR edits]. I'll poke around a little more to see if there is a better solution. I'm new to this repo and to Svelte.

Edit: tried coming at it from a different angle, but no dice.