### PR TITLE
Fix node version of the CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node with version 14
+      - name: Setup node with version 16
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci

--- a/src/routes/help/submitting.svelte
+++ b/src/routes/help/submitting.svelte
@@ -174,7 +174,9 @@
 
 <h2>JSON Snippet</h2>
 <pre>
-	{JSON.stringify(jsonSnippet,null,4)}<button on:click={copy}>{clipboardCopy ? 'Copied' : 'Copy'}</button>
+{JSON.stringify(jsonSnippet, null, 4)}<button on:click={copy}
+		>{clipboardCopy ? 'Copied' : 'Copy'}</button
+	>
 </pre>
 <br />
 Copy this snippet and add it to


### PR DESCRIPTION
Since the update of the version of SvelteKit, the Lint CI action is failing due to the fact that SvelteKit (or one of its dependencies) require Node 16.x to work