### PR TITLE
refactor: :recycle: update Svelte Society London event links

### DIFF
--- a/src/lib/components/Societies/societies.json
+++ b/src/lib/components/Societies/societies.json
@@ -6,7 +6,7 @@
 	{
 		"name": "London Svelte Meetup",
 		"country": "🇬🇧 Great Britain",
-		"url": "https://www.meetup.com/svelte/"
+		"url": "https://beta.guild.host/svelte-society-london/events/"
 	},
 	{
 		"name": "Svelte Dublin",

--- a/src/routes/about/+page.svx
+++ b/src/routes/about/+page.svx
@@ -1,6 +1,6 @@
 # About Svelte Society
 
-Svelte Society is the global Svelte community organization. It started as a series of meetups in [New York](https://www.downtomeet.com/Svelte-Society-NYC), [London](https://www.meetup.com/svelte/), and [Stockholm](https://www.meetup.com/Sveltejs-Society-Stockholm/), then combined into a global network in early 2020. Today it comprises:
+Svelte Society is the global Svelte community organization. It started as a series of meetups in [New York](https://www.downtomeet.com/Svelte-Society-NYC), [London](https://beta.guild.host/svelte-society-london/events/), and [Stockholm](https://www.meetup.com/Sveltejs-Society-Stockholm/), then combined into a global network in early 2020. Today it comprises:
 
 - [This website](https://github.com/svelte-society/sveltesociety.dev), which documents Recipes and Examples beyond [the official docs](https://svelte.dev/) and [Events about Svelte](https://sveltesociety.dev/events)
 - Podcast: https://www.svelteradio.com/


### PR DESCRIPTION
Updated the Svelte Society London event links to point to Guild

We're no longer using Meetup