### PR TITLE
only warn on missing ids

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -36,6 +36,9 @@ const config = {
 			$utils: path.resolve('./src/lib/utils'),
 			$styles: path.resolve('./src/lib/styles'),
 			$stores: path.resolve('./src/lib/stores')
+		},
+		prerender: {
+			handleMissingId: 'warn'
 		}
 	}
 };


### PR DESCRIPTION
Mandatory: this is not a permanent solution.

The recipes pages have anchor links but don't actually render the ids, and the components page has way too many links with encoded ids which needs to handled in Kit's prerenderer. For now, this should make the builds succeed.