### PR TITLE
Added `adapter-node-ws`

### DIFF
--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -2876,5 +2876,15 @@
 		"category": "SvelteKit Adapters",
 		"stars": 3,
 		"tags": ["integrations"]
+	},
+	{
+		"title": "@carlosv2/adapter-node-ws",
+		"url": "https://github.com/carlosV2/adapter-node-ws",
+		"description": "Adapter for SvelteKit apps that generates a standalone Node server with support for WebSockets.",
+		"npm": "@carlosv2/adapter-node-ws",
+		"addedOn": "2023-02-21",
+		"category": "SvelteKit Adapters",
+		"tags": ["async loading", "async data"],
+		"stars": 0
 	}
 ]

--- a/src/routes/components/components.json
+++ b/src/routes/components/components.json
@@ -2884,7 +2884,7 @@
 		"npm": "@carlosv2/adapter-node-ws",
 		"addedOn": "2023-02-21",
 		"category": "SvelteKit Adapters",
-		"tags": ["async loading", "async data"],
+		"tags": ["integrations"],
 		"stars": 0
 	}
 ]


### PR DESCRIPTION
This package is a collection of techniques to get WebSockets integrated in SvelteKit through the node adapter. It is in its infancy but it is already functional.