### PR TITLE
chore: Make `eslint-plugin-svelte` as official

### DIFF
--- a/src/routes/tools/tools.json
+++ b/src/routes/tools/tools.json
@@ -306,7 +306,7 @@
 		"category": "Linting and Formatting",
 		"tags": ["official"],
 		"stars": 135
-	}
+	},
 	{
 		"title": "full-client-server-sveltekit",
 		"url": "https://www.npmjs.com/package/full-client-server-sveltekit",

--- a/src/routes/tools/tools.json
+++ b/src/routes/tools/tools.json
@@ -172,15 +172,6 @@
 	},
 	{
 		"addedOn": "2021-08-09T10:14:05.723Z",
-		"title": "eslint-plugin-svelte3",
-		"category": "Linting and Formatting",
-		"description": "An ESLint plugin for Svelte v3 components.",
-		"url": "https://github.com/sveltejs/eslint-plugin-svelte3",
-		"tags": ["official"],
-		"stars": 289
-	},
-	{
-		"addedOn": "2021-08-09T10:14:05.723Z",
 		"title": "prettier-plugin-svelte",
 		"category": "Linting and Formatting",
 		"description": "Format your svelte components using prettier.",
@@ -307,15 +298,15 @@
 		"stars": 7
 	},
 	{
-		"title": "@ota-meshi/eslint-plugin-svelte",
-		"url": "https://github.com/ota-meshi/eslint-plugin-svelte",
+		"title": "eslint-plugin-svelte",
+		"url": "https://github.com/sveltejs/eslint-plugin-svelte",
 		"description": "ESLint plugin that applies own rules to Svelte",
-		"npm": "@ota-meshi/eslint-plugin-svelte",
+		"npm": "eslint-plugin-svelte",
 		"addedOn": "2022-04-16",
 		"category": "Linting and Formatting",
-		"tags": [],
-		"stars": 0
-	},
+		"tags": ["official"],
+		"stars": 135
+	}
 	{
 		"title": "full-client-server-sveltekit",
 		"url": "https://www.npmjs.com/package/full-client-server-sveltekit",


### PR DESCRIPTION
And I removed `eslint-plugin-svelte3` because this plugin is deprecated.