### PR TITLE
Removed duplicate entry for Flavio Copes' Svelte handbook 

### DIFF
--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -1,11 +1,6 @@
 <script>
 	const booksFromPublisher = [
 		{
-			name: 'Svelte Handbook',
-			link: 'https://flaviocopes.com/page/svelte-handbook/',
-			author: 'Flavio Copes'
-		},
-		{
 			name: 'Svelte 3 Up and Running',
 			link: 'https://www.amazon.com/dp/B08D6T6BKS/',
 			author: 'Alessandro Segala'


### PR DESCRIPTION
Removed Flavio Copes' self published Svelte Handbook from the  major publishers book list