### PR TITLE
Fix typo in context testing example

### DIFF
--- a/src/routes/recipes/testing-and-debugging/unit-testing-svelte-component/+page.svx
+++ b/src/routes/recipes/testing-and-debugging/unit-testing-svelte-component/+page.svx
@@ -111,7 +111,7 @@ As with slots, there is no programmatic interface for the Context API (setContex
 	export let context_key;
 	export let context_value;
 
-	setContext(key, value);
+	setContext(context_key, context_value);
 </script>
 
 <svelte:component this={Component} />


### PR DESCRIPTION
Fixes a small typo in the `unit-testing-svelte-component` page.