### PR TITLE
Update info on Parcel plugins. Fixes #448

### DIFF
--- a/src/routes/tools/tools.json
+++ b/src/routes/tools/tools.json
@@ -35,9 +35,16 @@
 		"tags": []
 	},
 	{
+		"title": "parcel-transformer-svelte3-plus",
+		"category": "Bundler Plugins",
+		"description": "Transformer plugin for Parcel v2; works with Svelte 3 & Svelte 4",
+		"repository": "https://github.com/HellButcher/parcel-transformer-svelte3-plus",
+		"tags": []
+	},
+	{
 		"title": "parcel-plugin-svelte",
 		"category": "Bundler Plugins",
-		"description": "A parcel plugin that enables svelte support",
+		"description": "A Parcel v1 plugin that enables Svelte support",
 		"repository": "https://github.com/DeMoorJasper/parcel-plugin-svelte",
 		"tags": []
 	},


### PR DESCRIPTION
As discussed in #448, this adds what I believe to be the best Svelte integration for Parcel v2, while clarifying that the Parcel plugin already present is only for Parcel v1.