### PR TITLE
feat: Add zod schemas for CI validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"test": "vitest",
-		"lint": "prettier --check ./**/*.{js,ts,css,md,svelte,html,json} && eslint --ignore-path .gitignore .",
+		"lint": "prettier --check ./**/*.{js,ts,css,md,svelte,html,json} && eslint --ignore-path .gitignore . && node scripts/validateData.js",
 		"format": "prettier --write ./**/*.{js,ts,css,md,svelte,html,json}",
 		"prepare": "husky install"
 	},
@@ -42,7 +42,8 @@
 		"typescript": "^5.1.6",
 		"undici": "^5.22.1",
 		"vite": "^4.4.2",
-		"vitest": "^0.33.0"
+		"vitest": "^0.33.0",
+		"zod": "^3.21.4"
 	},
 	"lint-staged": {
 		"*.{js,ts,css,md,svx,svelte,html,json}": "prettier --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ devDependencies:
   vitest:
     specifier: ^0.33.0
     version: 0.33.0
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
 
 packages:
 
@@ -3051,4 +3054,8 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true

--- a/scripts/validateData.js
+++ b/scripts/validateData.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+import { componentsSchema, templatesSchema, toolsSchema } from '../src/lib/schemas.js';
+import components from '../src/routes/components/components.json' assert { type: 'json' };
+import templates from '../src/routes/templates/templates.json' assert { type: 'json' };
+import tools from '../src/routes/tools/tools.json' assert { type: 'json' };
+
+componentsSchema.parse(components);
+console.log('Validated components.json');
+
+templatesSchema.parse(templates);
+console.log('Validated templates.json');
+
+toolsSchema.parse(tools);
+console.log('Validated tools.json');

--- a/src/lib/schemas.js
+++ b/src/lib/schemas.js
@@ -3,11 +3,31 @@ import { z } from 'zod';
 export const componentsSchema = z.array(
 	z.object({
 		title: z.string(),
-		url: z.string().optional(),
-		repository: z.string(),
+		npm: z
+			.string()
+			.regex(/(@[\w-]+\/)?[\w-]+/)
+			.optional(),
+		url: z.string().url().optional(),
+		repository: z.string().url(),
 		description: z.string(),
-		npm: z.string().optional(),
-		category: z.string(),
+		category: z.enum([
+			'Display Components',
+			'Developer Experience',
+			'Internationalization',
+			'CSS and Layout',
+			'Icons',
+			'Multimedia',
+			'Testing',
+			'Data Visualisation',
+			'Integration',
+			'Design Pattern',
+			'Stores',
+			'Routers',
+			'SvelteKit Adapters',
+			'Design System',
+			'User Interaction',
+			'Forms & User Input'
+		]),
 		tags: z.array(z.string()).optional()
 	})
 );
@@ -15,9 +35,10 @@ export const componentsSchema = z.array(
 export const templatesSchema = z.array(
 	z.object({
 		title: z.string(),
-		repository: z.string(),
+		url: z.string().url().optional(),
+		repository: z.string().url(),
 		description: z.string(),
-		category: z.string(),
+		category: z.enum(['Svelte Add', 'SvelteKit', 'Svelte']),
 		tags: z.array(z.string()).optional()
 	})
 );
@@ -25,9 +46,20 @@ export const templatesSchema = z.array(
 export const toolsSchema = z.array(
 	z.object({
 		title: z.string(),
-		repository: z.string(),
+		npm: z
+			.string()
+			.regex(/(@[\w-]+\/)?[\w-]+/)
+			.optional(),
+		url: z.string().url().optional(),
+		repository: z.string().url(),
 		description: z.string(),
-		category: z.string(),
+		category: z.enum([
+			'Debugging',
+			'Linting and Formatting',
+			'Editor Extensions',
+			'Bundler Plugins',
+			'Preprocessors'
+		]),
 		tags: z.array(z.string()).optional()
 	})
 );

--- a/src/lib/schemas.js
+++ b/src/lib/schemas.js
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const componentsSchema = z.array(
+	z.object({
+		title: z.string(),
+		url: z.string().optional(),
+		repository: z.string(),
+		description: z.string(),
+		npm: z.string().optional(),
+		category: z.string(),
+		tags: z.array(z.string()).optional()
+	})
+);
+
+export const templatesSchema = z.array(
+	z.object({
+		title: z.string(),
+		repository: z.string(),
+		description: z.string(),
+		category: z.string(),
+		tags: z.array(z.string()).optional()
+	})
+);
+
+export const toolsSchema = z.array(
+	z.object({
+		title: z.string(),
+		repository: z.string(),
+		description: z.string(),
+		category: z.string(),
+		tags: z.array(z.string()).optional()
+	})
+);


### PR DESCRIPTION
This adds the main feature of #427, which is Zod validation of the JSON files during linting.

Note that the `npm` field is currently optional; this is because `svelte-layout-resizable` and `SvelteStore` are missing this field. This can be corrected in a subsequent PR.