### PR TITLE
Fix SEO URL

### DIFF
--- a/src/lib/components/Seo.svelte
+++ b/src/lib/components/Seo.svelte
@@ -8,7 +8,7 @@
 		'We are a volunteer global network of Svelte fans that strive to promote Svelte and its ecosystem. As a service to the community, this site is a central index of events, a components directory, as well as recipes and other useful resources. Join us or help us out!';
 	export let image =
 		'https://raw.githubusercontent.com/svelte-society/sveltesociety.dev/main/static/images/metatag.png';
-	export let url = `https://${$page.host}${$page.url.pathname}`;
+	export let url = `https://${$page.url.host}${$page.url.pathname}`;
 	export let twitterHandle = '@sveltesociety';
 </script>
 


### PR DESCRIPTION
The `Seo.svelte` file currently gets the host URL from an invalid `$page.host`, which should be `$page.url.host`.

The current live shows `<meta name="og:url" content="https://undefined/">`