### PR TITLE
fix: Remove unused todaysDate function

### DIFF
--- a/src/routes/help/submitting/+page.svelte
+++ b/src/routes/help/submitting/+page.svelte
@@ -63,19 +63,6 @@
 		type = types.find((t) => t.value == typeQuery) || types[0];
 	});
 
-	function padWithZero(date) {
-		return date.toString().padStart(2, '0');
-	}
-
-	function todaysDate() {
-		const date = new Date();
-		const day = padWithZero(date.getDate());
-		const month = padWithZero(date.getMonth() + 1);
-		const year = date.getFullYear();
-		const sep = '-';
-		return [year, month, day].join(sep);
-	}
-
 	async function clearCategoryAndTags() {
 		await tick();
 		category = null;


### PR DESCRIPTION
The `addedOn` field was removed in this commit: https://github.com/svelte-society/sveltesociety.dev/commit/69fbd37b42af504cd2c3964a96f6e629ca8ef03a

This function is no longer necessary, and generates an eslint warning.