### PR TITLE
fix: Make active prop optional on Link.svelte

### DIFF
--- a/src/lib/components/layout/Link.svelte
+++ b/src/lib/components/layout/Link.svelte
@@ -1,5 +1,6 @@
-<script>
-	export let path, active;
+<script lang="ts">
+	export let path: string;
+	export let active = false;
 </script>
 
 <li>


### PR DESCRIPTION
Before this fix, `src/routes/+page.svelte` reports the following errors:

`Property 'active' is missing in type '{ path: string; }' but required in type '{ path: any; active: any; }'.`