### PR TITLE
fix: Add missing properties to Recipe type

### DIFF
--- a/src/lib/stores/recipes.ts
+++ b/src/lib/stores/recipes.ts
@@ -2,7 +2,9 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
 type Recipe = {
-	meta: unknown;
+	title: string;
+	layout: string;
+	icon?: string;
 	filename: string;
 	path: string;
 	children: Recipe[];


### PR DESCRIPTION
Fixes the following TS errors in `src/lib/layouts/Recipes.svelte`:

![image](https://github.com/svelte-society/sveltesociety.dev/assets/1667261/098d6701-b00f-48ac-b82f-fe0b2e6e8a3b)
