### PR TITLE
fix: Remove explicit SvelteKit typing

### DIFF
--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -2,8 +2,7 @@
 	import Societies from '$lib/components/Societies/index.svelte';
 	import EventListElement from '$lib/components/EventListElement/index.svelte';
 	import Seo from '$lib/components/Seo.svelte';
-	import type { PageData } from './$types';
-	export let data: PageData;
+	export let data;
 </script>
 
 <Seo title="Events" />

--- a/src/routes/events/+page.ts
+++ b/src/routes/events/+page.ts
@@ -1,8 +1,7 @@
 import { error } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
 import { getPages } from '../pageList';
 
-export async function load(): Promise<PageLoad> {
+export async function load() {
 	const events = await getPages(import.meta.glob('./**/*.svx'));
 
 	if (events) {

--- a/src/routes/recipes/+layout.ts
+++ b/src/routes/recipes/+layout.ts
@@ -1,9 +1,8 @@
 import { error } from '@sveltejs/kit';
 import '$styles/highlight.css';
-import type { PageLoad } from './$types';
 import { getPages } from '../pageList';
 
-export async function load(): Promise<PageLoad> {
+export async function load() {
 	const pages = (await getPages(import.meta.glob('./**/*.svx'))).map((element) => ({
 		...element,
 		path: '/recipes' + element.path.substring(1)


### PR DESCRIPTION
As per https://svelte.dev/blog/zero-config-type-safety and discussion on #427

Also `export async function load(): Promise<PageLoad>` actually causes a TS error which is fixed by removing the type. I think this has to do with the difference between typing function declarations and function expressions; the [SvelteKit load docs](https://kit.svelte.dev/docs/load) show how to type function expressions which do work in this case.