### PR TITLE
fix: Add sveltekit sync to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+      - name: Run sync
+        run: pnpm run sync
       - name: Run lint
         run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"start": "vite dev --open",
 		"build": "vite build",
 		"preview": "vite preview",
+		"sync": "svelte-kit sync",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"test": "vitest",
 		"lint": "prettier --check ./**/*.{js,ts,css,md,svelte,html,json} && eslint . && node scripts/validateData.js",


### PR DESCRIPTION
Since #500, eslint depends on tsconfig. On missed CI cache, the sveltekit post-install sync command runs. However, when cache is hit, sync does not run, so tsconfig does not generate and CI breaks.