### PR TITLE
chore: Improve PR linting instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## 🎯 Changes
+
+<!-- What changes are made in this PR? Is it a feature or a package submission? -->
+
+## ✅ Checklist
+
+- [ ] I have given my PR a descriptive title
+- [ ] I have run `pnpm run lint` locally on my changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Svelte Society Website
 
-Using SvelteKit!
+Welcome to Svelte Society! This repository hosts the main website, which serves as a central index of events, a components directory, as well as recipes and other useful resources.
 
 ## Developing
 
@@ -9,17 +9,10 @@ In order to start a development server:
 ```bash
 pnpm install
 pnpm run dev
-
-# or start the server and open the app in a new browser tab
-pnpm run start
 ```
 
-## Building
+## Contributing
 
-Before creating a production version of your app, install an [adapter](https://kit.svelte.dev/docs#adapters) for your target environment. Then:
+If you would like to improve the site, you are very welcome to submit a PR! The website has a [form](https://sveltesociety.dev/help/submitting?type=component) which helps streamline adding your package or resource.
 
-```bash
-pnpm run build
-```
-
-> You can preview the built app with `pnpm run preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.
+Please locally ensure your code passes `pnpm run lint` before submitting your PR. If you have Prettier formatting issues, please run `pnpm run format`.

--- a/src/routes/help/submitting/+page.svelte
+++ b/src/routes/help/submitting/+page.svelte
@@ -166,9 +166,9 @@
 </pre>
 <br />
 Copy this snippet and add it to
-<a href="{repoURL}/blob/main/src/routes/{pathName}/{pathName}.json">{pathName}.json</a>. You can
-propose your changes
-<a href="{repoURL}/edit/main/src/routes/{pathName}/{pathName}.json">directly in GitHub</a>.
+<a href="{repoURL}/blob/main/src/routes/{pathName}/{pathName}.json">{pathName}.json</a>. Before
+submitting a PR, please clone your changes locally and run:
+<pre>pnpm run lint</pre>
 
 <style>
 	.json-generator,


### PR DESCRIPTION
## 🎯 Changes

The most common reason PRs don't get merged is linting issues. The readme was previously 99% the default create-svelte template - I've added info about linting and formatting. I've also added a PR template with a linting reminder, and added a reminder to the submission generator form.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
