### PR TITLE
feat: Use `@sindresorhus/slugify` to generate category IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"devDependencies": {
 		"@actions/core": "^1.10.1",
 		"@macfja/svelte-persistent-store": "2.4.1",
+		"@sindresorhus/slugify": "^2.2.1",
 		"@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ devDependencies:
   '@macfja/svelte-persistent-store':
     specifier: 2.4.1
     version: 2.4.1(svelte@4.2.8)
+  '@sindresorhus/slugify':
+    specifier: ^2.2.1
+    version: 2.2.1
   '@sveltejs/adapter-static':
     specifier: ^3.0.0
     version: 3.0.0(@sveltejs/kit@2.0.0)
@@ -574,6 +577,21 @@ packages:
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
+  /@sindresorhus/slugify@2.2.1:
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+    dev: true
+
+  /@sindresorhus/transliterate@1.6.0:
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      escape-string-regexp: 5.0.0
     dev: true
 
   /@sveltejs/adapter-static@3.0.0(@sveltejs/kit@2.0.0):
@@ -1253,6 +1271,11 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
     dev: true
 
   /eslint-compat-utils@0.1.2(eslint@8.55.0):

--- a/src/lib/SearchableJson.svelte
+++ b/src/lib/SearchableJson.svelte
@@ -1,11 +1,12 @@
 <script>
+	import slugify from '@sindresorhus/slugify';
 	import ComponentCard from '$lib/components/ComponentIndex/Card.svelte';
 	import List from '$lib/components/ComponentIndex/CardList.svelte';
 	import SearchLayout from '$layouts/SearchLayout.svelte';
 	import { extractUnique } from '$lib/utils/extractUnique';
 	import Seo from '$lib/components/Seo.svelte';
 	import Search from '$lib/components/Search.svelte';
-	import Select from '../lib/components/Select.svelte';
+	import Select from '$lib/components/Select.svelte';
 	import { packageManager } from '$stores/packageManager';
 
 	export let data;
@@ -19,8 +20,6 @@
 	$: dataToDisplay = data.map((line) => ({ ...dataDefault, ...line }));
 
 	$: categories = extractUnique(dataToDisplay, 'category');
-
-	export let categoryId = {};
 </script>
 
 <Seo title={displayTitle} />
@@ -39,9 +38,7 @@
 				facetsConfig={[
 					{
 						title: 'Category',
-						identifier: 'category',
-						isClearable: true,
-						showIndicator: true
+						identifier: 'category'
 					},
 					{
 						title: 'Tags',
@@ -81,10 +78,7 @@
 	</section>
 	<section slot="items">
 		{#each categories as category}
-			<List
-				title={category.label || 'Unclassified'}
-				id={categoryId[category.label] || category.label || 'unclassified'}
-			>
+			<List title={category.label || 'Unclassified'} id={slugify(category.label) || 'unclassified'}>
 				{#each dataToDisplay.filter((d) => d.category === category.value || (!categories
 							.map((v) => v.value)
 							.includes(d.category) && category.value === '')) as cardData}

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -1,27 +1,10 @@
 <script>
 	import components from './components.json';
-	import SearchableJson from '../searchableJson.svelte';
+	import SearchableJson from '$lib/SearchableJson.svelte';
 	import { injectStars } from '$utils/stars';
-
-	const categoryId = {
-		Animations: 'animations',
-		'Data Visualisation': 'data-vis',
-		'Design Pattern': 'design-patterns',
-		'Design System': 'design-systems',
-		'Developer Experience': 'dx',
-		'Forms & User Input': 'input',
-		Integration: 'integrations',
-		'Rich Text Editor': 'text-editors',
-		Routers: 'routers',
-		Stores: 'stores',
-		'SvelteKit Adapters': 'adapters',
-		Testing: 'testing',
-		'User Interaction': 'ui'
-	};
 </script>
 
 <SearchableJson
-	{categoryId}
 	data={injectStars(components)}
 	displayTitle="Components"
 	displayTitleSingular="component"

--- a/src/routes/templates/+page.svelte
+++ b/src/routes/templates/+page.svelte
@@ -1,18 +1,10 @@
 <script>
 	import templates from './templates.json';
-	import SearchableJson from '../searchableJson.svelte';
+	import SearchableJson from '$lib/SearchableJson.svelte';
 	import { injectStars } from '$utils/stars';
-
-	const categoryId = {
-		Sapper: 'sapper',
-		Svelte: 'svelte',
-		'Svelte Add': 'adders',
-		SvelteKit: 'svelte-kit'
-	};
 </script>
 
 <SearchableJson
-	{categoryId}
 	data={injectStars(templates)}
 	displayTitle="Template"
 	displayTitleSingular="template"

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -1,19 +1,10 @@
 <script>
 	import tools from '../tools/tools.json';
-	import SearchableJson from '../searchableJson.svelte';
+	import SearchableJson from '$lib/SearchableJson.svelte';
 	import { injectStars } from '$utils/stars';
-
-	const categoryId = {
-		'Bundler Plugins': 'bundling',
-		Debugging: 'debugging',
-		'Editor Extensions': 'editor-support',
-		'Linting and Formatting': 'code-quality',
-		Preprocessors: 'preprocessors'
-	};
 </script>
 
 <SearchableJson
-	{categoryId}
 	data={injectStars(tools)}
 	displayTitle="Tools"
 	displayTitleSingular="tool"


### PR DESCRIPTION
## 🎯 Changes

`SearchableJson.svelte` currently requires each category to be manually mapped to a slugified category ID. This package handles the conversion and will be more flexible if new categories are added. Since `SearchableJson.svelte` is shared, I've moved it from `/src/routes` into `/src/lib`.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
