### PR TITLE
feat: Require svelte script `lang="ts"`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,6 +35,7 @@ const config = {
 	rules: {
 		'@typescript-eslint/array-type': 'off',
 		'@typescript-eslint/consistent-type-definitions': 'off',
+		'svelte/block-lang': ['error', { script: ['ts'] }],
 		'svelte/no-at-html-tags': 'off',
 		'svelte/valid-compile': 'off'
 	}

--- a/src/lib/Mermaid.svelte
+++ b/src/lib/Mermaid.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte';
 
 	let graph = null;

--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Tag from '../Tag.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { packageManager as manager } from '$stores/packageManager';

--- a/src/lib/components/ComponentIndex/CardList.svelte
+++ b/src/lib/components/ComponentIndex/CardList.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let title;
 	export let id = `category-${encodeURI(title)}`;
 </script>

--- a/src/lib/components/EventListElement/index.svelte
+++ b/src/lib/components/EventListElement/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Icon from '$lib/components/Icon/index.svelte';
 	export let title,
 		date,

--- a/src/lib/components/Icon/index.svelte
+++ b/src/lib/components/Icon/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let name;
 	export let width = '24px';
 	export let height = '24px';

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import SvelteSelect from 'svelte-select';
 
 	export let value;

--- a/src/lib/components/Seo.svelte
+++ b/src/lib/components/Seo.svelte
@@ -1,4 +1,4 @@
-<script type="ts">
+<script lang="ts">
 	import { page } from '$app/stores';
 
 	const brand = 'Svelte Society';

--- a/src/lib/components/Societies/index.svelte
+++ b/src/lib/components/Societies/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Icon from '$lib/components/Icon/index.svelte';
 	import societies from './societies.json';
 </script>

--- a/src/lib/components/Tag.svelte
+++ b/src/lib/components/Tag.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let title = '';
 	export let variant;
 	export let click = undefined;

--- a/src/lib/components/_SocialLinks/Link.svelte
+++ b/src/lib/components/_SocialLinks/Link.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let path, image, alt;
 </script>
 

--- a/src/lib/components/layout/Footer.svelte
+++ b/src/lib/components/layout/Footer.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	// get the year for the copyright statement
 	var date = new Date();
 	var year = date.getFullYear();

--- a/src/lib/components/recipes/CategoryTree.svelte
+++ b/src/lib/components/recipes/CategoryTree.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/stores';
 
 	export let nodes;

--- a/src/lib/layouts/EventPage.svelte
+++ b/src/lib/layouts/EventPage.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Seo from '$lib/components/Seo.svelte';
 
 	export let title = '';

--- a/src/lib/layouts/Recipe.svelte
+++ b/src/lib/layouts/Recipe.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import CategoryTree from '$lib/components/recipes/CategoryTree.svelte';
 	import Icon from '$lib/components/Icon/index.svelte';
 	import { categories } from '$lib/stores/recipes';

--- a/src/lib/layouts/RecipeCategory.svelte
+++ b/src/lib/layouts/RecipeCategory.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Icon from '$lib/components/Icon/index.svelte';
 	import { categories } from '$lib/stores/recipes';
 	import { page } from '$app/stores';

--- a/src/lib/layouts/SearchLayout.svelte
+++ b/src/lib/layouts/SearchLayout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let title;
 </script>
 

--- a/src/routes/about/+layout.svelte
+++ b/src/routes/about/+layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Seo from '$lib/components/Seo.svelte';
 </script>
 

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import components from './components.json';
 	import SearchableJson from '../searchableJson.svelte';
 	import { injectStars } from '$utils/stars';

--- a/src/routes/recipes/svelte-language-fundamentals/reactivity/+page.svx
+++ b/src/routes/recipes/svelte-language-fundamentals/reactivity/+page.svx
@@ -24,7 +24,8 @@ The following works as expected and update the dom:
 	}
 </script>
 
-<button on:click={updateNum}>Update</button><p>{num}</p>
+<button on:click={updateNum}>Update</button>
+<p>{num}</p>
 ```
 
 Svelte can see that there is an assignment to a top-level variable and knows to re-render after the `num` variable is modified.
@@ -89,7 +90,8 @@ This is the sort of problem you may run into when dealing with objects. Since ob
 	}
 </script>
 
-<button on:click={updateNum}>Update</button><p>{obj.num}</p>
+<button on:click={updateNum}>Update</button>
+<p>{obj.num}</p>
 ```
 
 In this example, when we reassign `o.num` we are updating the value assigned to `obj` but since we are not updating the actual `obj` variable Svelte does not trigger an update. Svelte does not trace these kinds of values back to a variable defined at the top level and has no way of knowing if it has updated or not. Whenever you want to update the local component state, any reassignments must be performed on the _actual_ variable, not just the value itself.
@@ -109,7 +111,8 @@ Another situation that can sometimes cause unexpected results is when you reassi
 	}
 </script>
 
-<button on:click={() => updateNum(obj)}>Update</button><p>{num}</p>
+<button on:click={() => updateNum(obj)}>Update</button>
+<p>{num}</p>
 ```
 
 This example behaves the same as the previous example, except it is perhaps even more confusing. In this case, the `obj` variable is being _shadowed_ while inside the function, so any assignments to `obj` inside this function are assignments to the function parameter rather than the top-level `obj` variable. It refers to the same value, and it has the same name, but it is a _different_ variable inside the function scope.

--- a/src/routes/recipes/svelte-language-fundamentals/reactivity/+page.svx
+++ b/src/routes/recipes/svelte-language-fundamentals/reactivity/+page.svx
@@ -24,8 +24,7 @@ The following works as expected and update the dom:
 	}
 </script>
 
-<button on:click={updateNum}>Update</button>
-<p>{num}</p>
+<button on:click={updateNum}>Update</button><p>{num}</p>
 ```
 
 Svelte can see that there is an assignment to a top-level variable and knows to re-render after the `num` variable is modified.
@@ -90,8 +89,7 @@ This is the sort of problem you may run into when dealing with objects. Since ob
 	}
 </script>
 
-<button on:click={updateNum}>Update</button>
-<p>{obj.num}</p>
+<button on:click={updateNum}>Update</button><p>{obj.num}</p>
 ```
 
 In this example, when we reassign `o.num` we are updating the value assigned to `obj` but since we are not updating the actual `obj` variable Svelte does not trigger an update. Svelte does not trace these kinds of values back to a variable defined at the top level and has no way of knowing if it has updated or not. Whenever you want to update the local component state, any reassignments must be performed on the _actual_ variable, not just the value itself.
@@ -111,8 +109,7 @@ Another situation that can sometimes cause unexpected results is when you reassi
 	}
 </script>
 
-<button on:click={() => updateNum(obj)}>Update</button>
-<p>{num}</p>
+<button on:click={() => updateNum(obj)}>Update</button><p>{num}</p>
 ```
 
 This example behaves the same as the previous example, except it is perhaps even more confusing. In this case, the `obj` variable is being _shadowed_ while inside the function, so any assignments to `obj` inside this function are assignments to the function parameter rather than the top-level `obj` variable. It refers to the same value, and it has the same name, but it is a _different_ variable inside the function scope.

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	const booksFromPublisher = [
 		{
 			name: 'Svelte 3 Up and Running',

--- a/src/routes/searchableJson.svelte
+++ b/src/routes/searchableJson.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import ComponentCard from '$lib/components/ComponentIndex/Card.svelte';
 	import List from '$lib/components/ComponentIndex/CardList.svelte';
 	import SearchLayout from '$layouts/SearchLayout.svelte';

--- a/src/routes/templates/+page.svelte
+++ b/src/routes/templates/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import templates from './templates.json';
 	import SearchableJson from '../searchableJson.svelte';
 	import { injectStars } from '$utils/stars';

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import tools from '../tools/tools.json';
 	import SearchableJson from '../searchableJson.svelte';
 	import { injectStars } from '$utils/stars';


### PR DESCRIPTION
## 🎯 Changes

Enables https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang/ - enforces adding `lang="ts"` to `.svelte` files, meaning these components can fully use typescript.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
