### PR TITLE
fix: Disable prerendering on redirect routes

### DIFF
--- a/src/routes/components/+page.server.ts
+++ b/src/routes/components/+page.server.ts
@@ -1,5 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 
+export const prerender = false;
+
 export const load = async () => {
 	redirect(308, '/packages');
 };

--- a/src/routes/tools/+page.server.ts
+++ b/src/routes/tools/+page.server.ts
@@ -1,5 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 
+export const prerender = false;
+
 export const load = async () => {
 	redirect(308, '/packages');
 };


### PR DESCRIPTION
## 🎯 Changes

The server should handle these redirects itself, so prerendering is unnecessary.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
