### PR TITLE
Add Amplify Adapter package

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -3301,5 +3301,13 @@
 		"npm": "svelte-enhanced-transitions",
 		"category": "CSS and Layout",
 		"tags": ["in-page navigation"]
+	},
+	{
+		"title": "Amplify Adapter",
+		"repository": "https://github.com/gzimbron/amplify-adapter",
+		"description": "Deploy Sveltekit SSR application to Aws Amplify (CI/CD)",
+		"npm": "amplify-adapter",
+		"category": "SvelteKit Adapters",
+		"tags": ["ssr","components and libraries","layout and structure"]
 	}
 ]

--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -3308,6 +3308,6 @@
 		"description": "Deploy Sveltekit SSR application to Aws Amplify (CI/CD)",
 		"npm": "amplify-adapter",
 		"category": "SvelteKit Adapters",
-		"tags": ["ssr","components and libraries","layout and structure"]
+		"tags": ["ssr", "components and libraries", "layout and structure"]
 	}
 ]


### PR DESCRIPTION
Adding Sveltekit adapter: "Amplify Adapter", it allows to deploy an ssr Sveltekit App to AWS Amplify by CI/CD

## 🎯 Changes

<!-- What changes are made in this PR? Is it a feature or a package submission? -->

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
