### PR TITLE
fix: Make repos open in new tab

### DIFF
--- a/src/lib/components/ComponentIndex/Card.svelte
+++ b/src/lib/components/ComponentIndex/Card.svelte
@@ -37,11 +37,11 @@
 		</div>
 		<div>
 			{#if repository.includes('github')}
-				<a class="repo" title="Go to the source code" href={repository}
+				<a class="repo" title="Go to the source code" target="_blank" href={repository}
 					><img style="display:inline" src="/images/github_logo.svg" alt="github logo" /></a
 				>
 			{:else if repository.includes('gitlab')}
-				<a class="repo" title="Go to the source code" href={repository}
+				<a class="repo" title="Go to the source code" target="_blank" href={repository}
 					><img style="display:inline" src="/images/gitlab_logo.svg" alt="gitlab logo" /></a
 				>
 				<!-- {:else} -->


### PR DESCRIPTION
## 🎯 Changes

Adds `target="_blank"` so repos open in new tab.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
