### PR TITLE
Comment "License Information" section at /about

### DIFF
--- a/src/routes/about/+page.svx
+++ b/src/routes/about/+page.svx
@@ -38,6 +38,8 @@ However, a lot of work remains to be done. The original Svelte Society meetups a
 
 Special thanks to [VueMeetups](https://events.vuejs.org/code-of-conduct/#english) for the basis of this Code of Conduct.
 
+<!--- Uncomment this before closing issue #566
 ## License information
 
 The license information can be found [here](https://sveltesociety.dev/licenses).
+-->


### PR DESCRIPTION
## 🎯 Changes

As descripted in issue #566 there's a broken link at `/about` (`/licenses` returns a 404).  
I think that the section should be disabled until the `/licenses` endpoint is enabled.  
If this PR is merged, I would put a comment at issue #566, "Do not close this issue until the code commented in the PR #576 is uncommented".

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
