### PR TITLE
ci: Only run cron workflow on source repo

### DIFF
--- a/.github/workflows/fetch-latest-data.yml
+++ b/.github/workflows/fetch-latest-data.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update:
+    if: github.repository == 'svelte-society/sveltesociety.dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 🎯 Changes

Every Sunday, I get emailed about workflows which fail on forks of this repo. Provided users update their fork, this change will prevent the workflow from running in forked repos.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
