### PR TITLE
Add passkey authentication project to the templates

### DIFF
--- a/src/routes/templates/templates.json
+++ b/src/routes/templates/templates.json
@@ -710,5 +710,11 @@
 		"repository": "https://github.com/falkomerr/sveltekit-starter",
 		"description": "Starter for SvelteKit with FSD, shadcn-svelte and tailwind",
 		"categories": ["sveltekit", "typescript", "code-splitting"]
+	},
+	{
+		"title": "Lucia + Passkeys + Social Sign In",
+		"repository": "https://github.com/passlock-dev/svelte-passkeys",
+		"description": "Authentication template supporting passkeys, mailbox verification emails, social sign in and more. (Lucia, Melt UI, Superforms, Tailwind + others)",
+		"categories": ["sveltekit", "typescript"]
 	}
 ]


### PR DESCRIPTION
## 🎯 Changes

New SvelteKit template (Lucia, Passkeys, Social Sign In etc)

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
