### PR TITLE
fix: rename AgnosUI package

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -2976,7 +2976,7 @@
 		"url": "https://amadeusitgroup.github.io/AgnosUI/latest/",
 		"repository": "https://github.com/AmadeusITGroup/AgnosUI",
 		"description": "Reactive, accessible and Bootstrap-compliant components for Svelte.",
-		"npm": "@agnos-ui/svelte",
+		"npm": "@agnos-ui/svelte-bootstrap",
 		"categories": ["design-system", "ui-components"]
 	},
 	{


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Is it a feature or a package submission? -->
Since version 0.3.0, we have renamed the npm package from `@agnos-ui/svelte` to `@agnos-ui/svelte-bootstrap`.
This PR updates the entry accordingly.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
