### PR TITLE
Update Societies | Norway

### DIFF
--- a/src/lib/components/Societies/societies.json
+++ b/src/lib/components/Societies/societies.json
@@ -42,10 +42,9 @@
 		"discord": "https://discord.gg/YWbEhX99"
 	},
 	{
-		"name": "Svelte Bergen",
+		"name": "Svelte Norway",
 		"country": "🇳🇴 Norway",
-		"twitter": "@stephanevanraes",
-		"url": "https://www.downtomeet.com/Svelte-Bergen"
+		"discord": "https://discord.gg/Agneq5jQ7P"
 	},
 	{
 		"name": "Svelte Society Stockholm",


### PR DESCRIPTION
## 🎯 Changes

Changed name from "Svelte Bergen" to "Svelte Norway"
Removed _downtomeet_ due to absolute inactivity
Removed _twitter_ due to deletion of account
Added _discord_ because the future lacks harmony

## ✅ Checklist

- [x] I have given my PR a descriptive title (yeah sure)
- [x] I have run `pnpm run lint` locally on my changes (promise)
