### PR TITLE
Fix NPM + Publint scripts

### DIFF
--- a/scripts/updateNpm.js
+++ b/scripts/updateNpm.js
@@ -35,6 +35,9 @@ writeFileSync('src/lib/data/npm.json', JSON.stringify(output));
 
 /** @param {import('zod').infer<typeof packagesSchema>[0]} pkg */
 async function processPackage(pkg) {
+	if (!('npm' in pkg)) {
+		return {};
+	}
 	const { stdout } = await execAsync(`npm view ${pkg.npm} --json`);
 	const data = JSON.parse(stdout.toString());
 	const version = data.version;

--- a/scripts/updatePublint.js
+++ b/scripts/updatePublint.js
@@ -16,6 +16,9 @@ import { chunk } from './chunk.js';
 const injectVersions = (input) => {
 	const output = [];
 	for (const item of input) {
+		if (!('npm' in item)) {
+			continue;
+		}
 		/** @type {string} */
 		const version = npm[item.npm]?.version;
 		if (version) {


### PR DESCRIPTION
## 🎯 Changes

With the introduction of package outside of NPM (5f5ebdf78f57815770e05fccdd5da7b6ccce58e8), the file `src/routes/packages/packages.json` can have an item where `npm` node is missing.

This PR fix the scripts that use it

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
