### PR TITLE
Update societies.json - Berlin society URL

### DIFF
--- a/src/lib/components/Societies/societies.json
+++ b/src/lib/components/Societies/societies.json
@@ -32,7 +32,6 @@
 	{
 		"name": "Svelte Berlin",
 		"country": "🇩🇪 Germany",
-		"url": "https://lu.ma/ud76698y",
 		"githuburl": "https://github.com/nika-d/svelte-berlin"
 	},
 	{


### PR DESCRIPTION
Deleted link to a specific event, because github url (README.md) is our "homepage" now.

This is a follow up to [@MacFJA request](https://github.com/svelte-society/sveltesociety.dev/pull/643#issuecomment-2221271001) on providing a link that will never be outdated. 

## 🎯 Changes

<!-- What changes are made in this PR? Is it a feature or a package submission? -->

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes ---- did not try, cause just deleted 1 line in .json file, hope, thats ok..?
