### PR TITLE
chore: remove svelte-toolbox

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -1246,13 +1246,6 @@
 		"repository": "https://github.com/storybookjs/storybook"
 	},
 	{
-		"description": "A UI component library for Svelte implementing Google's Material Design specification",
-		"npm": "svelte-toolbox",
-		"categories": ["ui-components", "design-system"],
-		"title": "svelte-toolbox",
-		"repository": "https://github.com/svelte-toolbox/svelte-toolbox"
-	},
-	{
 		"description": "Automated Svelte routes",
 		"npm": "@roxi/routify",
 		"categories": ["routers"],


### PR DESCRIPTION
strangely this github repo now redirects to a rust UI library :laughing: 