### PR TITLE
Remove broken template links

### DIFF
--- a/src/routes/templates/templates.json
+++ b/src/routes/templates/templates.json
@@ -469,18 +469,6 @@
 		"categories": ["typescript", "preprocessors", "svelte"]
 	},
 	{
-		"title": "Svelte + FAST + Vite template",
-		"repository": "https://github.com/microsoft/fast/tree/master/examples/svelte-starters/svelte-fast-starter",
-		"description": "A Svelte + FAST + Vite starter project",
-		"categories": ["svelte"]
-	},
-	{
-		"title": "Svelte + FAST + Vite + TypeScript template",
-		"repository": "https://github.com/microsoft/fast/tree/master/examples/svelte-starters/svelte-fast-typescript-starter",
-		"description": "A Svelte + FAST + Vite + TypeScript starter project",
-		"categories": ["svelte"]
-	},
-	{
 		"title": "svelte-vite-typescript-tailwindcss-template",
 		"repository": "https://github.com/skshahriarahmedraka/vite-svelte-tailwind-template",
 		"description": "svelte & vite & typescript & tailwindcss",


### PR DESCRIPTION
Fixes https://github.com/svelte-society/sveltesociety.dev/issues/724

## 🎯 Changes

Fixes https://github.com/svelte-society/sveltesociety.dev/issues/724

The top two links on the templates page are broken links. It looks like msft removed the svelte examples from this repo.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes (not locally, but CI did)
