### PR TITLE
Added `adapter-bun-next`

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -3271,5 +3271,12 @@
 		"description": "A Svelte wrapper that automatically prefetches pages based on the user's cursor position.",
 		"npm": "svelte-proximity-prefetch",
 		"categories": ["data-fetching"]
+	},
+	{
+		"title": "svelte-adapter-bun-next",
+		"repository": "https://github.com/TheOrdinaryWow/svelte-adapter-bun-next",
+		"description": "Adapter for SvelteKit apps that generates a standalone Bun.js server.",
+		"npm": "svelte-adapter-bun-next",
+		"categories": ["sveltekit-adapters"]
 	}
 ]


### PR DESCRIPTION
## 🎯 Changes

Since [svelte-adapter-bun](https://github.com/gornostay25/svelte-adapter-bun) seems not to be active (https://github.com/gornostay25/svelte-adapter-bun/issues/74), I decided to write a new one.

This adapter integrates the latest Bun features, and generates a standalone Bun.js server.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
