### PR TITLE
feat: tweak saved page link button ux in sidebar

### DIFF
--- a/src/routes/(app)/(public)/saved/+page.server.ts
+++ b/src/routes/(app)/(public)/saved/+page.server.ts
@@ -1,9 +1,8 @@
 import { error, redirect } from '@sveltejs/kit'
 import type { PageServerLoad } from './$types'
-import type { Content } from '$lib/types/content'
 
 export const load = (async ({ locals, url }) => {
-	if (!locals?.user?.id) redirect(302, '/')
+	if (!locals?.user?.id) redirect(302, '/auth/github')
 
 	try {
 		// Get pagination parameters

--- a/src/routes/(app)/_components/LeftSidebar.svelte
+++ b/src/routes/(app)/_components/LeftSidebar.svelte
@@ -14,7 +14,7 @@
 
 	const links = $derived([
 		{ name: 'Home', href: '/' },
-		...(user ? [{ name: 'Saved', href: '/saved' }] : []),
+		{ name: 'Saved', href: '/saved', disabled: !user },
 		{ name: 'CURATED', href: null },
 		{ name: 'Announcements', href: '/announcement' },
 		{ name: 'Collections', href: '/collection' },
@@ -38,15 +38,26 @@
 			{#each links as link}
 				{#if link.href}
 					<li
+						title={link.disabled ? 'Please login to view saved content' : ''}
 						class={[
-							{ 'bg-svelte-500 text-white': page.url.pathname === link.href },
+							{
+								'bg-svelte-500 text-white': page.url.pathname === link.href,
+								'cursor-not-allowed': link.disabled
+							},
 							'w-full rounded-sm px-2 py-0.5'
 						]}
 					>
-						<a class="block w-full" href={preserveSearchParams(link.href)}>{link.name}</a>
+						<a
+							class={['block w-full', { 'pointer-events-none text-gray-700': link.disabled }]}
+							href={preserveSearchParams(link.href)}
+							aria-disabled={link.disabled}
+						>
+							{link.name}
+							{link.disabled ? ' (disabled)' : ''}
+						</a>
 					</li>
 				{:else}
-					<li class="mt-2 px-2 py-0.5 text-xs font-extralight">
+					<li class="mt-2 px-2 py-0.5 text-xs font-thin">
 						{link.name}
 					</li>
 				{/if}


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Is it a feature or a package submission? -->

I was clicking on the saved button in the sidebar, and nothing was happening so I was confused. This should clear that up by redirecting my to auth if I'm not logged in.

Alternatives considered:
- Grey out the button if you're not logged in
- Allow it to be clicked but toast the user if they're not logged in, that they should be

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [ ] I have run `pnpm run lint` locally on my changes
