### PR TITLE
remove sveltekit-adapter-firebase

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -2011,13 +2011,6 @@
 		"categories": ["auth", "integrations"]
 	},
 	{
-		"title": "sveltekit-adapter-firebase",
-		"repository": "https://github.com/simonnepomuk/monorepo/tree/main/libs/sveltekit-adapter-firebase",
-		"description": "SvelteKit Adapter for Firebase",
-		"npm": "sveltekit-adapter-firebase",
-		"categories": ["integrations", "sveltekit-adapters"]
-	},
-	{
 		"title": "sveltekit-search-params",
 		"repository": "https://github.com/paoloricciuti/sveltekit-search-params",
 		"description": "The best way to read and WRITE from query params in sveltekit.",


### PR DESCRIPTION
The repository 404s. Additionally, [Cloud Run now supports SvelteKit without extra configuration](https://cloud.google.com/run/docs/quickstarts/frameworks/deploy-sveltekit-service#writing), which means Firebase App Hosting will support it too.

## 🎯 Changes

<!-- What changes are made in this PR? Is it a feature or a package submission? -->

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [ ] I have run `pnpm run lint` locally on my changes

Lint failed, but doesn't seem related to this change. The error was `SyntaxError: Unexpected identifier 'assert'`
