### PR TITLE
Added @thebrenny/svelte-adapter-h3

### DIFF
--- a/src/routes/packages/packages.json
+++ b/src/routes/packages/packages.json
@@ -3311,5 +3311,12 @@
 		"description": "Ported the functionality of @sveltejs/adapter-node to hono.",
 		"npm": "adapter-hono",
 		"categories": ["sveltekit-adapters"]
+	},
+	{
+		"title": "@TheBrenny/svelte-adapter-h3",
+		"repository": "https://github.com/TheBrenny/svelte-adapter-h3",
+		"description": "Ported the functionality of adapter-hono to H3.",
+		"npm": "@thebrenny/svelte-adapter-h3",
+		"categories": ["sveltekit-adapters"]
 	}
 ]


### PR DESCRIPTION
adding adapter-h3 to (legacy) packages.json

H3 hoists middleware up to the global middleware stack when mounting sub-apps. This isn't good because svelte effectively only uses middlewares. This was worked around by using `app.all("/**/*", (e) => svelteApp.fetch(e))`.