### PR TITLE
feat: refresh og images every 14 days

### DIFF
--- a/src/lib/server/db/migrations/003_add_fetched_at.sql
+++ b/src/lib/server/db/migrations/003_add_fetched_at.sql
@@ -1,3 +1,0 @@
-alter table content add column fetched_at text;
-
-update content set fetched_at = created_at;

--- a/src/lib/server/db/migrations/003_add_fetched_at.sql
+++ b/src/lib/server/db/migrations/003_add_fetched_at.sql
@@ -1,0 +1,3 @@
+alter table content add column fetched_at text;
+
+update content set fetched_at = created_at;

--- a/src/lib/server/db/migrations/003_cleanup_thumbnail.sql
+++ b/src/lib/server/db/migrations/003_cleanup_thumbnail.sql
@@ -1,0 +1,5 @@
+update content set
+  metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '//', '/'));
+
+update content set
+  metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '.html', '.png'));

--- a/src/lib/server/services/importers/github.ts
+++ b/src/lib/server/services/importers/github.ts
@@ -2,22 +2,9 @@ import type { CacheService } from '../cache'
 import type { ExternalContentService, ExternalContentData } from '../external-content'
 
 import fs from 'node:fs'
+import path from 'node:path'
 
 const { STATE_DIRECTORY = '.state_directory' } = process.env
-
-async function get_metadata({ url, html }) {
-	if (url) {
-		html = await fetch(url).then((r) => r.text())
-	}
-
-	const head = html.split('<head>').at(1)?.split('</head>').at(0)
-
-	const match = head.match(/<meta property="og:image" content="([^"]+)" \/>/m)
-
-	if (!match) return
-
-	return match[1]
-}
 
 interface GitHubRepository {
 	id: number
@@ -90,14 +77,14 @@ export class GitHubImporter {
 			throw new Error('Failed to fetch image')
 		}
 
-		const dir = [STATE_DIRECTORY, 'files', 'gh', repository.full_name].join('/')
+		const dir = path.join(STATE_DIRECTORY, 'files', 'gh', repository.full_name)
 		const extension = response.headers.get('content-type')?.split('/').at(-1)
-		const file_path = dir + '/thumbnail.' + extension
+		const file_path = path.join(dir, 'thumbnail.' + extension)
 
 		fs.mkdirSync(dir, { recursive: true })
 		fs.writeFileSync(file_path, Buffer.from(await response.arrayBuffer()))
 
-		const thumbnail = ['/files', 'gh', repository.full_name, '/thumbnail.' + extension].join('/')
+		const thumbnail = path.join('/files', 'gh', repository.full_name, 'thumbnail.' + extension)
 		contentData.metadata.thumbnail = thumbnail
 
 		return this.externalContentService.upsertExternalContent(contentData)

--- a/src/lib/server/services/importers/github.ts
+++ b/src/lib/server/services/importers/github.ts
@@ -86,7 +86,7 @@ export class GitHubImporter {
 			console.error(error)
 		}
 
-		if (!response) {
+		if (!response || !response.headers.get('content-type')?.includes('image')) {
 			throw new Error('Failed to fetch image')
 		}
 

--- a/src/lib/server/services/importers/youtube.ts
+++ b/src/lib/server/services/importers/youtube.ts
@@ -2,6 +2,7 @@ import type { CacheService } from '../cache'
 import type { ExternalContentService, ExternalContentData } from '../external-content'
 
 import fs from 'node:fs'
+import path from 'node:path'
 
 const { STATE_DIRECTORY = '.state_directory' } = process.env
 
@@ -64,11 +65,11 @@ export class YouTubeImporter {
 
 		const response = await fetch(`https://i.ytimg.com/vi/${video.id}/maxresdefault.jpg`)
 
-		const dir = [STATE_DIRECTORY, 'files', 'yt', video.id].join('/')
+		const dir = path.join(STATE_DIRECTORY, 'files', 'yt', video.id)
 
 		fs.mkdirSync(dir, { recursive: true })
 
-		fs.writeFileSync(dir + '/thumbnail.jpg', Buffer.from(await response.arrayBuffer()))
+		fs.writeFileSync(path.join(dir, 'thumbnail.jpg'), Buffer.from(await response.arrayBuffer()))
 
 		const contentData = this.transformVideoToContent(video)
 

--- a/src/routes/files/[...path]/+server.ts
+++ b/src/routes/files/[...path]/+server.ts
@@ -8,14 +8,9 @@ if (!fs.existsSync(STATE_DIRECTORY)) {
 	fs.mkdirSync(STATE_DIRECTORY, { recursive: true })
 }
 
-const a = `update content set metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '//', '/'));`
-const a = `update content set metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '.html', '.png'));`
-
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params, request }) {
 	const p = decodeURIComponent(params.path)
-
-	const [source, ...rest] = p.split('/')
 
 	const file_path = path.normalize(path.join(STATE_DIRECTORY, 'files', p))
 
@@ -26,6 +21,8 @@ export async function GET({ params, request }) {
 	if (exists) {
 		stats = fs.statSync(file_path)
 	}
+
+	const [source, ...rest] = p.split('/')
 
 	switch (source) {
 		case 'gh': {

--- a/src/routes/files/[...path]/+server.ts
+++ b/src/routes/files/[...path]/+server.ts
@@ -26,7 +26,7 @@ export async function GET({ params, request }) {
 
 	switch (source) {
 		case 'gh': {
-			const T = 1000 * 60 * 3600 * 24 * 14 // 7 days
+			const T = 1000 * 60 * 3600 * 24 * 14 // 14 days
 
 			if (!exists || Date.now() - stats?.mtime.getTime() >= T) {
 				const [owner, repo] = rest

--- a/src/routes/files/[...path]/+server.ts
+++ b/src/routes/files/[...path]/+server.ts
@@ -8,17 +8,66 @@ if (!fs.existsSync(STATE_DIRECTORY)) {
 	fs.mkdirSync(STATE_DIRECTORY, { recursive: true })
 }
 
+const a = `update content set metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '//', '/'));`
+const a = `update content set metadata = json_replace(metadata,'$.thumbnail', replace(metadata ->> '$.thumbnail', '.html', '.png'));`
+
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params, request }) {
-	const file_path = path.normalize(
-		path.join(STATE_DIRECTORY, 'files', decodeURIComponent(params.path))
-	)
+	const p = decodeURIComponent(params.path)
 
-	if (!fs.existsSync(file_path)) {
+	const [source, ...rest] = p.split('/')
+
+	const file_path = path.normalize(path.join(STATE_DIRECTORY, 'files', p))
+
+	const exists = fs.existsSync(file_path)
+
+	let stats
+
+	if (exists) {
+		stats = fs.statSync(file_path)
+	}
+
+	switch (source) {
+		case 'gh': {
+			const T = 1000 * 60 * 3600 * 24 * 14 // 7 days
+
+			if (!exists || Date.now() - stats?.mtime.getTime() >= T) {
+				const [owner, repo] = rest
+
+				const og_image_url = `https://opengraph.githubassets.com/${crypto.randomUUID()}/${owner}/${repo}`
+
+				let response
+
+				try {
+					response = await fetch(og_image_url)
+				} catch (error) {
+					console.error(error)
+					break
+				}
+
+				if (!response.ok) {
+					console.log('Could not refresh OG image. Rate limit exceeded: ' + og_image_url)
+					break
+				}
+
+				fs.writeFileSync(file_path, Buffer.from(await response.arrayBuffer()))
+
+				stats = fs.statSync(file_path)
+
+				console.log('Refreshed OG image: ' + og_image_url)
+			}
+
+			break
+		}
+		case 'yt': {
+			break
+		}
+	}
+
+	if (!stats) {
 		return new Response('not found', { status: 404 })
 	}
 
-	const stats = fs.statSync(file_path)
 	const etag = `W/"${stats.size}-${stats.mtime.getTime()}"`
 
 	if (request.headers.get('if-none-match') === etag) {


### PR DESCRIPTION
> [!CAUTION]
> Let's first deploy this to `staging` and test it. After that I'll check and make sure everything is fine. Then we can deploy it to `production`.

This extends the `/files` endpoint and refreshes an image

- if it is older than `14 days` 
- if it currently does not exist on disc and needs to "heal" because the download previously failed (rate limit)