### PR TITLE
Add role name to admin user list

### DIFF
--- a/src/routes/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(admin)/admin/users/+page.server.ts
@@ -9,8 +9,17 @@ export const load = (async ({ url, locals }) => {
 	const users = locals.userService.getUsers({ limit: perPage, offset })
 	const totalUsers = locals.userService.getUserCount()
 
+	// Get role names for each user
+	const usersWithRoles = users.map((user) => {
+		const role = locals.roleService.getRoleById(user.role)
+		return {
+			...user,
+			role_name: role?.name || 'Unknown'
+		}
+	})
+
 	return {
-		users,
+		users: usersWithRoles,
 		pagination: {
 			count: totalUsers,
 			perPage,

--- a/src/routes/(admin)/admin/users/+page.svelte
+++ b/src/routes/(admin)/admin/users/+page.svelte
@@ -8,9 +8,10 @@
 	import Pagination from '$lib/ui/Pagination.svelte'
 	import type { User } from '$lib/server/services/user'
 
-	// Extended User interface to include created_at
+	// Extended User interface to include created_at and role_name
 	interface ExtendedUser extends User {
 		created_at: string
+		role_name: string
 	}
 
 	let { data } = $props()
@@ -29,6 +30,7 @@
 		{#snippet header(classes)}
 			<th scope="col" class={classes}>User</th>
 			<th scope="col" class={classes}>Email</th>
+			<th scope="col" class={classes}>Role</th>
 			<th scope="col" class={classes}>Location</th>
 			<th scope="col" class={classes}>Twitter</th>
 			<th scope="col" class={classes}>Created</th>
@@ -39,6 +41,7 @@
 				<span class="ml-2">{item.username}</span>
 			</td>
 			<td class="{classes} truncate">{item.email ?? '-'}</td>
+			<td class={classes}>{item.role_name}</td>
 			<td class={classes}>{item.location ?? '-'}</td>
 			<td class={classes}>{item.twitter ?? '-'}</td>
 			<td class={classes}>


### PR DESCRIPTION
## Background
The admin user list currently does not display the role associated with each user.

## Changes
- `src/routes/(admin)/admin/users/+page.server.ts`:
    - Modified the `load` function to fetch the role name for each user using `locals.roleService.getRoleById`.
    - Appended a `role_name` property to each user object in the returned data.
- `src/routes/(admin)/admin/users/+page.svelte`:
    - Extended the `ExtendedUser` interface to include `role_name`.
    - Added a new table header "Role".
    - Displayed the `role_name` for each user in the table.

## Testing
- [ ] Verify that the "Role" column is displayed in the admin user list.
- [ ] Confirm that correct role names are shown for users with assigned roles.
- [ ] Ensure users without an explicit role display "Unknown" in the role column.
