### PR TITLE
feat: use document scrollview

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,3 +26,8 @@
 			url('/fonts/Inter.woff2') format('woff2');
 	}
 }
+
+::view-transition-group(header),
+::view-transition-group(announcement) {
+	z-index: 10;
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -41,15 +41,16 @@
 
 <Head seo_config={page.data.meta || fallbackMeta} />
 
-<div class="flex h-screen flex-col">
+<div class="flex min-h-screen flex-col">
 	<Header user={data.user} announcement={data.announcement} />
 
 	<main
-		class="relative mx-auto grid w-full max-w-[1440px] flex-1 grid-cols-1 gap-2 overflow-hidden sm:grid-cols-[1.5fr_5fr_2.5fr] md:gap-4 lg:gap-6"
+		class="relative mx-auto grid w-full max-w-[1440px] flex-1 grid-cols-1 gap-2 sm:grid-cols-[1.5fr_5fr_2.5fr] md:gap-4 lg:gap-6"
+		style:--header-height={data.announcement ? '7.5rem' : '5rem'}
 	>
 		<LeftSidebar {links} />
 
-		<div class="flex flex-col overflow-y-scroll px-4 pt-8">
+		<div class="flex flex-col px-4 pt-8">
 			<div class="mb-6 flex-shrink-0 sm:hidden">
 				<MobileMenu {links} upcomingEvents={data.upcomingEvents} />
 			</div>

--- a/src/routes/(app)/_components/Header.svelte
+++ b/src/routes/(app)/_components/Header.svelte
@@ -5,13 +5,13 @@
 	let { user, announcement } = $props()
 </script>
 
-<header class="border-svelte-900 border-b-4 py-4">
+<header class="border-svelte-900 sticky top-0 z-10 border-b-4 bg-white py-4">
 	<div
 		class="mx-auto grid w-full max-w-[1440px] grid-cols-[auto_1fr_auto] items-center gap-4 px-4 sm:grid-cols-[1.5fr_5fr_2.5fr]"
 	>
-		<a href="/" class="flex items-center gap-2">
+		<a href="/" class="mr-auto flex items-center gap-2">
 			<svg
-				class="h-auto w-24"
+				class="h-11 w-auto"
 				height="55"
 				width="117"
 				viewBox="0 0 117 55"
@@ -68,7 +68,7 @@
 	</div>
 </header>
 {#if announcement}
-	<div class="bg-svelte-900 flex w-full place-content-center p-2">
+	<div class="bg-svelte-900 sticky top-20 z-10 flex w-full place-content-center p-2">
 		<a href={announcement.href} class="text-semibold mx-auto text-white underline">
 			{announcement.text}
 		</a>

--- a/src/routes/(app)/_components/Header.svelte
+++ b/src/routes/(app)/_components/Header.svelte
@@ -5,7 +5,10 @@
 	let { user, announcement } = $props()
 </script>
 
-<header class="border-svelte-900 sticky top-0 z-10 border-b-4 bg-white py-4">
+<header
+	class="border-svelte-900 sticky top-0 z-10 border-b-4 bg-white py-4"
+	style:view-transition-name="header"
+>
 	<div
 		class="mx-auto grid w-full max-w-[1440px] grid-cols-[auto_1fr_auto] items-center gap-4 px-4 sm:grid-cols-[1.5fr_5fr_2.5fr]"
 	>
@@ -68,7 +71,10 @@
 	</div>
 </header>
 {#if announcement}
-	<div class="bg-svelte-900 sticky top-20 z-10 flex w-full place-content-center p-2">
+	<div
+		class="bg-svelte-900 sticky top-20 z-10 flex w-full place-content-center p-2"
+		style:view-transition-name="announcement"
+	>
 		<a href={announcement.href} class="text-semibold mx-auto text-white underline">
 			{announcement.text}
 		</a>

--- a/src/routes/(app)/_components/LeftSidebar.svelte
+++ b/src/routes/(app)/_components/LeftSidebar.svelte
@@ -12,7 +12,9 @@
 	let { links }: Props = $props()
 </script>
 
-<aside class="ml-4 hidden overflow-y-auto py-8 sm:block">
+<aside
+	class="sticky top-[var(--header-height)] ml-4 hidden max-h-[calc(100vh_-_var(--header-height))] overflow-y-auto py-8 sm:block"
+>
 	<nav>
 		<ul class="text-sm font-bold">
 			{#each links as link}

--- a/src/routes/(app)/_components/RightSidebar.svelte
+++ b/src/routes/(app)/_components/RightSidebar.svelte
@@ -25,7 +25,9 @@
 	let { upcomingEvents = [] }: { upcomingEvents?: UpcomingEvent[] } = $props()
 </script>
 
-<div class="@container mr-4 hidden space-y-4 overflow-y-auto py-8 sm:block">
+<div
+	class="@container sticky top-[var(--header-height)] mr-4 hidden max-h-[calc(100vh_-_var(--header-height))] space-y-4 overflow-y-auto py-8 sm:block"
+>
 	<div class="mb-4 grid grid-cols-1 items-start gap-1 @xs:grid-cols-[1fr_auto]">
 		<h3 class="text-lg font-semibold">Interested in contributing?</h3>
 		<Button href="/submit" size="sm"><Plus />Submit Post</Button>


### PR DESCRIPTION
Use the default document scroll view to make sveltekits scroll-position restore work.

Changed the logo in the header to a fixed height instead of a fixed width to make the header a fixed height as well (needed for the `top:xx` style of the sticky elements). Before the logo had a height of 45.13px and the header 81.13px, now the logo has a height of 44px and the header 80px.

*Not sure if staging is the correct branch?*