### PR TITLE
Fix tags selector and preview fetching issues on submit page

### DIFF
--- a/src/routes/(app)/(public)/submit/+page.server.ts
+++ b/src/routes/(app)/(public)/submit/+page.server.ts
@@ -53,7 +53,11 @@ export const load = (async ({ locals, url }) => {
 
 	const tags = locals.tagService.getTags({ limit: 50 })
 
-	const form = await superValidate(zod4(schema))
+	const form = await superValidate(zod4(schema), {
+		defaults: {
+			tags: []
+		}
+	})
 
 	return {
 		form,

--- a/src/routes/(app)/(public)/submit/+page.svelte
+++ b/src/routes/(app)/(public)/submit/+page.svelte
@@ -246,7 +246,7 @@
 			name="tags"
 			label="Tags"
 			description="Select relevant tags for your submission"
-			options={data.tags.map((tag) => ({
+			options={(data.tags || []).map((tag) => ({
 				label: tag.name,
 				value: tag.id
 			}))}

--- a/src/routes/(app)/(public)/submit/+page.svelte
+++ b/src/routes/(app)/(public)/submit/+page.svelte
@@ -26,6 +26,10 @@
 	let previewLoading = $state(false)
 	let previewError = $state<string | null>(null)
 
+	// Track previous values to detect actual changes to these specific fields
+	let previousVideoUrl = $state<string>('')
+	let previousGithubRepo = $state<string>('')
+
 	const fetchYouTubePreview = debounce(async (url: string) => {
 		if (!url) {
 			videoPreview = null
@@ -78,15 +82,25 @@
 		}
 	}, 1000)
 
+	// Only trigger when video URL field specifically changes, not on any form field change
 	$effect(() => {
 		if ($formData.type === 'video' && 'url' in $formData) {
-			fetchYouTubePreview($formData.url)
+			const currentUrl = $formData.url || ''
+			if (currentUrl !== previousVideoUrl) {
+				previousVideoUrl = currentUrl
+				fetchYouTubePreview(currentUrl)
+			}
 		}
 	})
 
+	// Only trigger when github repo field specifically changes, not on any form field change
 	$effect(() => {
 		if ($formData.type === 'library' && 'github_repo' in $formData) {
-			fetchGitHubPreview($formData.github_repo)
+			const currentRepo = $formData.github_repo || ''
+			if (currentRepo !== previousGithubRepo) {
+				previousGithubRepo = currentRepo
+				fetchGitHubPreview(currentRepo)
+			}
 		}
 	})
 </script>


### PR DESCRIPTION
## Summary

Fixes two critical issues on the submit page that were causing errors and poor user experience.

## Issues Fixed

### 1. Tags Selector Undefined Error
**Problem**: Tags selector was throwing "can't access property 'map', i.data.tags is undefined" error when loading the submit page.

**Solution**:
- Added default empty array for tags field in form initialization
- Added null-safe operator to data.tags.map() call

### 2. Excessive Preview API Calls
**Problem**: Preview fetching for videos and libraries was triggering on every form field change (typing in tags, description, notes, etc.), causing unnecessary API calls and poor UX.

**Solution**:
- Added previousVideoUrl and previousGithubRepo state variables to track changes
- Modified $effect blocks to compare current vs previous values
- Only trigger fetch when the specific URL or repo field actually changes
- Debouncing (1000ms) still applies for smooth typing experience

## Technical Details

The second issue was caused by Svelte 5's fine-grained reactivity - `$effect` blocks track all reactive state accessed within them. By comparing previous values before calling the fetch functions, we prevent unnecessary API calls while maintaining the preview functionality (duplicate detection, metadata display).

## Testing

All 10 content submission E2E tests pass:
- ✓ 4 recipe submission tests
- ✓ 3 video submission tests
- ✓ 3 library submission tests

## Changes

- Modified: `src/routes/(app)/(public)/submit/+page.server.ts`
- Modified: `src/routes/(app)/(public)/submit/+page.svelte`

## Preview Functionality Maintained

- YouTube video preview and duplicate detection
- GitHub repository preview and duplicate detection
- Error handling and loading states
- Submit button disabling for existing content