### PR TITLE
Move sharp from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
 		"vite": "^7.1.12",
 		"vitest": "^4.0.4",
 		"satori": "^0.18.3",
-		"sharp": "^0.34.4",
 		"zod": "^4.1.12"
 	},
 	"private": true,
+	"dependencies": {
+		"sharp": "^0.34.4"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
## Summary
- Moves `sharp` package from `devDependencies` to `dependencies` in package.json

## Rationale
Sharp is used in production for image processing (specifically for OG image generation). It should be a production dependency to ensure it's installed in production environments.

## Changes
- Removed `sharp` from `devDependencies`
- Added `sharp` to new `dependencies` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)