### PR TITLE
Fix SuperDebug visibility and Tag component URL preservation

### DIFF
--- a/src/lib/ui/Tag.svelte
+++ b/src/lib/ui/Tag.svelte
@@ -25,15 +25,20 @@
 			tagList.push(tag.slug)
 		}
 
-		const rootUrl = new URL(url.origin)
+		// Clone the current URL to preserve all searchParams
+		const newUrl = new URL(url)
 
+		// Update or remove the tags parameter
 		if (tagList.length > 0) {
-			rootUrl.searchParams.set('tags', tagList.join(','))
+			newUrl.searchParams.set('tags', tagList.join(','))
+		} else {
+			newUrl.searchParams.delete('tags')
 		}
 
-		rootUrl.searchParams.delete('page')
+		// Reset pagination when filtering changes
+		newUrl.searchParams.delete('page')
 
-		return rootUrl.pathname + rootUrl.search
+		return newUrl.pathname + newUrl.search
 	}
 </script>
 

--- a/src/routes/(app)/(public)/submit/+page.svelte
+++ b/src/routes/(app)/(public)/submit/+page.svelte
@@ -288,4 +288,7 @@
 	</Form>
 </div>
 
-<SuperDebug data={$formData} />
+<!-- Debug only in development -->
+{#if import.meta.env?.DEV}
+	<SuperDebug data={$formData} />
+{/if}


### PR DESCRIPTION
## Summary

This PR fixes two small issues in preparation for launch:

- **SuperDebug component visibility**: Ensures the debug component only shows in development mode
- **Tag component URL preservation**: Fixes tag filtering to preserve all existing URL search parameters

## Changes

### 1. SuperDebug Component (`src/routes/(app)/(public)/submit/+page.svelte`)
- Wrapped SuperDebug in `{#if import.meta.env?.DEV}` check
- Now consistent with other admin pages that already had this guard
- Prevents debug output from showing in production

### 2. Tag Component (`src/lib/ui/Tag.svelte`)
- Fixed URL construction to preserve all search parameters
- Changed from `new URL(url.origin)` (which loses params) to `new URL(url)` (which clones them)
- Now properly maintains search queries, filters, and other params when filtering by tags
- Only modifies `tags` parameter and resets `page` parameter as intended

## Testing

- [x] Verified SuperDebug only shows in dev mode
- [x] Tested tag filtering preserves search parameters
- [x] Confirmed existing functionality unchanged

## Impact

- Cleaner production builds (no debug output)
- Better UX (tag filtering doesn't lose user's search/filter state)
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)