### PR TITLE
Fix date display by removing relative dates

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -3,22 +3,10 @@ export function formatRelativeDate(date: string | null): string {
 		return 'Unknown date'
 	}
 
-	const now = new Date()
 	const inputDate = new Date(date)
-	const diffTime = now.getTime() - inputDate.getTime()
-	const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
-
-	if (diffDays === 0) {
-		return 'Today'
-	} else if (diffDays === 1) {
-		return 'Yesterday'
-	} else if (diffDays > 1 && diffDays <= 5) {
-		return `${diffDays} days ago`
-	} else {
-		return inputDate.toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric'
-		})
-	}
+	return inputDate.toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric'
+	})
 }


### PR DESCRIPTION
## Summary
Fixes #816 - Remove timezone-dependent relative dates (Today/Yesterday) and always show the actual formatted date.

The relative date calculation was causing confusion because it didn't properly account for timezone differences. Items would show "Today" when they were actually added yesterday in the user's local timezone.

## Changes
- Simplified `formatRelativeDate()` to always display the actual date format (e.g., "October 15, 2024")
- Removed day calculation logic that compared dates without timezone awareness

## Test Plan
- Verify that dates are now displayed in the full format instead of relative dates
- Check that dates are consistent regardless of user timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)