### PR TITLE
feat: update slugs

### DIFF
--- a/src/lib/server/db/migrations/006_update_slugs.sql
+++ b/src/lib/server/db/migrations/006_update_slugs.sql
@@ -1,0 +1,7 @@
+update content set slug = slug || '-' || lower(id);
+
+create trigger content___set_slug after insert on content begin
+  update content set
+    slug = slug || '-' || lower(new.id)
+  where id = new.id;
+end;


### PR DESCRIPTION
This PR

1. changes the slugs of all existing content items from `this-is-some-slug` to `this-is-some-slug-[id]`. `[id]` is transformed to lower case even though they are uppercase. It just looks better as a slug
2. adds an SQL trigger that changes the slug of new content items accordingly after they are inserted into the DB.