### PR TITLE
Replace placeholder sponsors with sponsorship CTA

### DIFF
--- a/src/routes/(app)/_components/MobileMenu.svelte
+++ b/src/routes/(app)/_components/MobileMenu.svelte
@@ -82,11 +82,13 @@
 				</div>
 
 				<div class="grid gap-2 rounded border border-slate-200 bg-gray-50 px-4 py-2 text-sm">
-					<h3 class="text-md font-bold">Our sponsors:</h3>
-					<ul class="flex flex-wrap gap-2">
-						<li>ACME Inc.</li>
-						<li>John Doe Inc.</li>
-					</ul>
+					<h3 class="text-md font-bold">Become a sponsor</h3>
+					<p class="text-xs text-gray-600">
+						Support Svelte Society and get your company featured here.
+						<a href="mailto:sponsor@sveltesociety.dev" class="text-orange-600 underline hover:text-orange-700">
+							Contact us
+						</a>
+					</p>
 				</div>
 
 				<UpcomingEvents events={upcomingEvents} onLinkClick={closeMenu} />

--- a/src/routes/(app)/_components/RightSidebar.svelte
+++ b/src/routes/(app)/_components/RightSidebar.svelte
@@ -42,11 +42,13 @@
 	</div>
 
 	<div class="grid gap-2 rounded border-1 border-slate-200 bg-gray-50 px-4 py-2 text-sm">
-		<h3 class="text-md font-bold">Our sponsors:</h3>
-		<ul class="flex flex-wrap gap-2">
-			<li>ACME Inc.</li>
-			<li>John Doe Inc.</li>
-		</ul>
+		<h3 class="text-md font-bold">Become a sponsor</h3>
+		<p class="text-xs text-gray-600">
+			Support Svelte Society and get your company featured here.
+			<a href="mailto:sponsor@sveltesociety.dev" class="text-orange-600 underline hover:text-orange-700">
+				Contact us
+			</a>
+		</p>
 	</div>
 
 	<UpcomingEvents events={upcomingEvents} />


### PR DESCRIPTION
## Summary

- Replace hardcoded placeholder sponsors with a call-to-action for potential sponsors
- Add email link to sponsor@sveltesociety.dev in both desktop and mobile sponsor cards
- Update sponsor card heading from "Our sponsors:" to "Become a sponsor"

## Changes

- Updated `RightSidebar.svelte` to include sponsorship CTA with mailto link
- Updated `MobileMenu.svelte` to match desktop experience
- Styled the email link with orange accent color and hover effect

## Test plan

- [ ] Verify sponsor card displays correctly in desktop right sidebar
- [ ] Verify sponsor card displays correctly in mobile menu
- [ ] Test mailto link opens email client with correct address
- [ ] Verify styling matches site design (orange accent, hover states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)