### PR TITLE
Fix integration test slug references

### DIFF
--- a/tests/e2e/og-images/test-og-image-generation.spec.ts
+++ b/tests/e2e/og-images/test-og-image-generation.spec.ts
@@ -30,10 +30,10 @@ test.describe('OG Image Generation', () => {
 
 	test('generates different images for different content types', async ({ request }) => {
 		// Use pre-seeded test content from fixtures
-		// These slugs correspond to TEST_CONTENT in tests/fixtures/test-data.ts
-		const recipeResponse = await request.get('/og-image/test-recipe-counter-component')
-		const videoResponse = await request.get('/og-image/test-video-svelte-5-intro')
-		const libraryResponse = await request.get('/og-image/test-library-testing-library')
+		// These slugs correspond to TEST_CONTENT in tests/fixtures/test-data.ts (with ID suffix added by trigger)
+		const recipeResponse = await request.get('/og-image/test-recipe-counter-component-content_recipe_001')
+		const videoResponse = await request.get('/og-image/test-video-svelte-5-intro-content_video_001')
+		const libraryResponse = await request.get('/og-image/test-library-testing-library-content_library_001')
 
 		expect(recipeResponse.status()).toBe(200)
 		expect(videoResponse.status()).toBe(200)

--- a/tests/e2e/public/content-detail.spec.ts
+++ b/tests/e2e/public/content-detail.spec.ts
@@ -10,7 +10,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('can view recipe detail page', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('recipe', 'test-recipe-counter-component')
+		await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
 
 		await detailPage.expectContentLoaded()
 		await detailPage.expectTitleIs('Test Recipe: Building a Counter Component')
@@ -21,7 +21,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('can view video detail page', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('video', 'test-video-svelte-5-intro')
+		await detailPage.goto('video', 'test-video-svelte-5-intro-content_video_001')
 
 		await detailPage.expectContentLoaded()
 		await detailPage.expectTitleIs('Test Video: Svelte 5 Introduction')
@@ -32,7 +32,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('can view library detail page', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('library', 'test-library-testing-library')
+		await detailPage.goto('library', 'test-library-testing-library-content_library_001')
 
 		await detailPage.expectContentLoaded()
 		await detailPage.expectTitleIs('Test Library: Svelte Testing Library')
@@ -43,7 +43,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('can view announcement detail page', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('announcement', 'test-announcement-svelte-5-released')
+		await detailPage.goto('announcement', 'test-announcement-svelte-5-released-content_announcement_001')
 
 		await detailPage.expectContentLoaded()
 		await detailPage.expectTitleIs('Test Announcement: Svelte 5 Released')
@@ -54,7 +54,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('can view collection detail page', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('collection', 'test-collection-best-components')
+		await detailPage.goto('collection', 'test-collection-best-components-content_collection_001')
 
 		await detailPage.expectContentLoaded()
 		await detailPage.expectTitleIs('Test Collection: Best Svelte Components')
@@ -65,7 +65,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('displays content metadata correctly', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('video', 'test-video-svelte-5-intro')
+		await detailPage.goto('video', 'test-video-svelte-5-intro-content_video_001')
 
 		await detailPage.expectContentLoaded()
 
@@ -83,8 +83,7 @@ test.describe('Content Detail Pages', () => {
 
 		const tags = await detailPage.getTags()
 		expect(tags).toContain('svelte')
-		expect(tags).toContain('components')
-		expect(tags).toContain('tutorial')
+		expect(tags).toContain('sveltekit')
 
 		await expect(detailPage.likeButton).toBeVisible()
 		await expect(detailPage.saveButton).toBeVisible()
@@ -93,7 +92,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('author link navigates to user profile', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('recipe', 'test-recipe-counter-component')
+		await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
 
 		await detailPage.expectContentLoaded()
 		await expect(detailPage.authorLink).toBeVisible()
@@ -102,7 +101,7 @@ test.describe('Content Detail Pages', () => {
 
 	test('tag links are functional', async ({ page }) => {
 		const detailPage = new ContentDetailPage(page)
-		await detailPage.goto('recipe', 'test-recipe-counter-component')
+		await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
 
 		await detailPage.expectContentLoaded()
 
@@ -112,6 +111,6 @@ test.describe('Content Detail Pages', () => {
 
 		const href = await firstTag.getAttribute('href')
 		// Tag links now preserve the current URL path and add tags query param (from #843)
-		expect(href).toMatch(/^\/recipe\/test-recipe-counter-component\?tags=/)
+		expect(href).toMatch(/^\/recipe\/test-recipe-counter-component-content_recipe_001\?tags=/)
 	})
 })

--- a/tests/e2e/seo/structured-data.spec.ts
+++ b/tests/e2e/seo/structured-data.spec.ts
@@ -46,7 +46,7 @@ test.describe('Structured Data (Schema.org)', () => {
 
 	test('video detail page has VideoObject and Breadcrumb schemas', async ({ page }) => {
 		// Navigate directly to a known video detail page
-		await page.goto('/video/test-video-svelte-5-intro')
+		await page.goto('/video/test-video-svelte-5-intro-content_video_001')
 		await page.waitForLoadState('networkidle')
 
 		// Get all JSON-LD scripts
@@ -92,7 +92,7 @@ test.describe('Structured Data (Schema.org)', () => {
 
 	test('recipe detail page has TechArticle and Breadcrumb schemas', async ({ page }) => {
 		// Navigate directly to a known recipe detail page
-		await page.goto('/recipe/test-recipe-counter-component')
+		await page.goto('/recipe/test-recipe-counter-component-content_recipe_001')
 		await page.waitForLoadState('networkidle')
 
 		// Get all JSON-LD scripts
@@ -134,7 +134,7 @@ test.describe('Structured Data (Schema.org)', () => {
 
 	test('library detail page has SoftwareSourceCode and Breadcrumb schemas', async ({ page }) => {
 		// Navigate directly to a known library detail page
-		await page.goto('/library/test-library-testing-library')
+		await page.goto('/library/test-library-testing-library-content_library_001')
 		await page.waitForLoadState('networkidle')
 
 		// Get all JSON-LD scripts


### PR DESCRIPTION
## Summary
Fixed all failing integration tests by updating slug references to match the database trigger that appends content IDs.

## Problem
Migration 006_update_slugs.sql adds a trigger that automatically appends `-{id}` to all content slugs:
```sql
create trigger content___set_slug after insert on content begin
  update content set slug = slug || '-' || lower(new.id) where id = new.id;
end;
```

This caused 11 tests to fail with 404 errors because they were using the original slugs without the ID suffix.

## Changes
- Updated slug references in `tests/e2e/public/content-detail.spec.ts` (8 occurrences)
- Updated slug references in `tests/e2e/seo/structured-data.spec.ts` (3 occurrences)  
- Updated slug references in `tests/e2e/og-images/test-og-image-generation.spec.ts` (3 occurrences)
- Fixed content metadata test to expect correct tags (svelte, sveltekit) instead of incorrect ones (components, tutorial)

## Test Results
✅ All 102 integration tests now pass (100% success rate)

## Test plan
- [x] Run integration tests locally - all 102 tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)