### PR TITLE
Fix sidebar category highlighting on all subroutes

### DIFF
--- a/src/routes/(app)/_components/LeftSidebar.svelte
+++ b/src/routes/(app)/_components/LeftSidebar.svelte
@@ -10,6 +10,13 @@
 	}
 
 	let { links }: Props = $props()
+
+	function isLinkActive(linkHref: string): boolean {
+		const pathname = page.url.pathname
+		if (pathname === linkHref) return true
+		if (linkHref !== '/' && pathname.startsWith(linkHref + '/')) return true
+		return false
+	}
 </script>
 
 <aside
@@ -24,7 +31,7 @@
 							title={link.disabled ? 'Please login to view saved content' : ''}
 							class={[
 								{
-									'bg-svelte-500 text-white': page.url.pathname === link.href,
+									'bg-svelte-500 text-white': isLinkActive(link.href),
 									'cursor-not-allowed': link.disabled
 								},
 								'w-full rounded-sm px-2 py-0.5'


### PR DESCRIPTION
## Summary
Fixes sidebar category highlighting to work on all subroutes, not just exact path matches.

## Changes
- Updated `LeftSidebar.svelte` to use `isLinkActive()` function
- Now highlights category links when on any subroute (e.g., `/library/some-slug` highlights "Libraries")

## Test plan
- Navigate to a category listing page (e.g., `/library`) - category should be highlighted
- Navigate to a detail page (e.g., `/library/some-slug`) - category should remain highlighted
- Navigate to deeply nested routes - category should remain highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)