### PR TITLE
Add clickable library thumbnails and display GitHub metadata on detail pages

### DIFF
--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -192,7 +192,7 @@
 		{:else if content.type === 'video'}
 			<Video {content} {priority} />
 		{:else if content.type === 'library'}
-			<Library {content} {priority} />
+			<Library {content} {priority} fullInfo={fullDescription} />
 		{:else if content.type === 'announcement'}
 			<!-- Announcements show rendered body on detail pages -->
 			{#if fullDescription && content.rendered_body}


### PR DESCRIPTION
## Summary
- Library thumbnails now link directly to GitHub repos (opens in new tab)
- Display rich GitHub metadata on library detail pages only (not in feed)
- Removed unnecessary complexity in Library component

## Changes
### Library Thumbnail Links
- Clicking a library thumbnail now opens the GitHub repo in a new tab
- Added `data-testid="library-thumbnail-link"` for testing
- Removed the unnecessary absolute overlay pattern that was covering the component

### GitHub Metadata Display
- **Owner info**: Shows avatar and clickable owner name
- **Stats**: Displays stars ⭐, forks 🍴, and open issues 🐛
- **Dates**: Shows "Last Updated" and "Created" dates
- All metadata is styled with gray background cards for visual hierarchy

### Conditional Display
- Metadata only appears on detail pages (when `fullDescription={true}`)
- Feed view remains clean with just the thumbnail and basic info
- Follows the same pattern as Recipe and Announcement content types

### Cleanup
- Removed redundant GitHub link from bottom of component (thumbnail already links)
- Removed the absolute positioned overlay in favor of simpler structure
- Kept npm link at bottom when available

## Testing
- Manually tested on both feed and detail pages
- Thumbnail correctly links to GitHub repos
- Metadata displays only on detail pages
- All links open in new tabs with proper `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)