### PR TITLE
Add NPM package link support for library imports

### DIFF
--- a/src/lib/ui/content/Library.svelte
+++ b/src/lib/ui/content/Library.svelte
@@ -16,6 +16,23 @@
 	const isGitHub = $derived(content.metadata?.externalSource?.source === 'github')
 	const hasStats = $derived(isGitHub && (content.metadata?.stars || content.metadata?.forks))
 
+	// Validate NPM package name - filter out invalid/placeholder names
+	const isValidNpmPackage = $derived.by(() => {
+		const npm = content.metadata?.npm
+		if (!npm) return false
+
+		// Filter out common placeholder/invalid names
+		const invalidNames = ['www', 'app', 'web', 'site', 'website', 'monorepo', 'workspace']
+		const lowerName = npm.toLowerCase()
+
+		if (invalidNames.includes(lowerName)) return false
+		if (lowerName.endsWith('-monorepo') || lowerName.endsWith('-workspace')) return false
+
+		// Valid NPM package name pattern
+		const validPackagePattern = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+		return validPackagePattern.test(npm)
+	})
+
 	// Determine loading strategy based on priority
 	const isAboveFold = priority === 'high'
 	const loadingAttr = isAboveFold ? 'eager' : 'lazy'
@@ -42,88 +59,90 @@
 			/>
 		</a>
 
-		{#if fullInfo}
-			<!-- Owner Info & Stats -->
-			<div class="flex flex-wrap items-center justify-between gap-3 rounded-md bg-gray-100 px-3 py-2">
-				{#if content.metadata?.owner}
-					<div class="flex items-center gap-2">
-						{#if content.metadata.owner.avatar}
-							<img
-								src={content.metadata.owner.avatar}
-								alt={content.metadata.owner.name}
-								class="h-6 w-6 rounded-full"
-								loading="lazy"
-							/>
-						{/if}
-						<a
-							href={content.metadata.owner.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="text-sm font-medium text-gray-700 hover:text-gray-900 hover:underline"
-						>
-							{content.metadata.owner.name}
-						</a>
-					</div>
-				{/if}
-
-				{#if hasStats}
-					<div class="flex flex-wrap items-center gap-4 text-sm text-gray-700">
-						{#if content.metadata?.stars}
-							<div class="flex items-center gap-1.5" title="Stars">
-								<span>⭐</span>
-								<span class="font-medium">{content.metadata.stars.toLocaleString()}</span>
-							</div>
-						{/if}
-						{#if content.metadata?.forks}
-							<div class="flex items-center gap-1.5" title="Forks">
-								<span>🍴</span>
-								<span class="font-medium">{content.metadata.forks.toLocaleString()}</span>
-							</div>
-						{/if}
-						{#if content.metadata?.issues}
-							<div class="flex items-center gap-1.5" title="Open Issues">
-								<span>🐛</span>
-								<span class="font-medium">{content.metadata.issues.toLocaleString()}</span>
-							</div>
-						{/if}
-					</div>
-				{/if}
-			</div>
-
-			<!-- Dates -->
-			<div class="flex flex-wrap items-center justify-between gap-4 rounded-md bg-gray-100 px-3 py-2 text-sm">
-				{#if content.metadata?.updatedAt}
-					<div class="flex items-center gap-2">
-						<span class="font-medium text-gray-600">Last Updated:</span>
-						<span class="text-gray-700">{formatRelativeDate(content.metadata.updatedAt)}</span>
-					</div>
-				{/if}
-				{#if content.metadata?.createdAt}
-					<div class="flex items-center gap-2">
-						<span class="font-medium text-gray-600">Created:</span>
-						<span class="text-gray-700">{formatRelativeDate(content.metadata.createdAt)}</span>
-					</div>
-				{/if}
-			</div>
-		{/if}
-
-		<!-- External Links -->
-		{#if content.metadata?.npm}
-			<div class="mt-auto">
-				<div class="flex items-center gap-3 text-xs">
+	{#if fullInfo}
+		<!-- Owner Info & Stats -->
+		<div class="flex flex-wrap items-center justify-between gap-3 rounded-md bg-gray-100 px-3 py-2">
+			{#if content.metadata?.owner}
+				<div class="flex items-center gap-2">
+					{#if content.metadata.owner.avatar}
+						<img
+							src={content.metadata.owner.avatar}
+							alt={content.metadata.owner.name}
+							class="h-6 w-6 rounded-full"
+							loading="lazy"
+						/>
+					{/if}
 					<a
-						href="https://www.npmjs.com/package/{content.metadata.npm}"
+						href={content.metadata.owner.url}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="relative z-20 flex items-center gap-1 text-orange-600 hover:text-orange-700"
-						onclick={(e) => e.stopPropagation()}
+						class="text-sm font-medium text-gray-700 hover:text-gray-900 hover:underline"
 					>
-						<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-							<path d="M12 2L2 7v10c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-10-5z" />
-						</svg>
-						npm
+						{content.metadata.owner.name}
 					</a>
 				</div>
+			{/if}
+
+			{#if hasStats}
+				<div class="flex flex-wrap items-center gap-4 text-sm text-gray-700">
+					{#if content.metadata?.stars}
+						<div class="flex items-center gap-1.5" title="Stars">
+							<span>⭐</span>
+							<span class="font-medium">{content.metadata.stars.toLocaleString()}</span>
+						</div>
+					{/if}
+					{#if content.metadata?.forks}
+						<div class="flex items-center gap-1.5" title="Forks">
+							<span>🍴</span>
+							<span class="font-medium">{content.metadata.forks.toLocaleString()}</span>
+						</div>
+					{/if}
+					{#if content.metadata?.issues}
+						<div class="flex items-center gap-1.5" title="Open Issues">
+							<span>🐛</span>
+							<span class="font-medium">{content.metadata.issues.toLocaleString()}</span>
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Dates -->
+		<div class="flex flex-wrap items-center justify-between gap-4 rounded-md bg-gray-100 px-3 py-2 text-sm">
+			{#if content.metadata?.updatedAt}
+				<div class="flex items-center gap-2">
+					<span class="font-medium text-gray-600">Last Updated:</span>
+					<span class="text-gray-700">{formatRelativeDate(content.metadata.updatedAt)}</span>
+				</div>
+			{/if}
+			{#if content.metadata?.createdAt}
+				<div class="flex items-center gap-2">
+					<span class="font-medium text-gray-600">Created:</span>
+					<span class="text-gray-700">{formatRelativeDate(content.metadata.createdAt)}</span>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- External Links -->
+	{#if isValidNpmPackage}
+		<div class="mt-auto rounded-md bg-gray-100 px-3 py-2">
+			<div class="flex items-center gap-2">
+				<span class="text-sm font-medium text-gray-600">NPM:</span>
+				<a
+					href="https://www.npmjs.com/package/{content.metadata.npm}"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-1.5 text-sm text-orange-600 hover:text-orange-700 hover:underline"
+					onclick={(e) => e.stopPropagation()}
+				>
+					<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+						<path d="M0 0h24v24H0V0z" fill="none"/>
+						<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+					</svg>
+					{content.metadata.npm}
+				</a>
 			</div>
-		{/if}
+		</div>
+	{/if}
 	</div>

--- a/tests/e2e/public/content-detail.spec.ts
+++ b/tests/e2e/public/content-detail.spec.ts
@@ -113,4 +113,23 @@ test.describe('Content Detail Pages', () => {
 		// Tag links now preserve the current URL path and add tags query param (from #843)
 		expect(href).toMatch(/^\/recipe\/test-recipe-counter-component-content_recipe_001\?tags=/)
 	})
+
+	test('library displays NPM package link when available', async ({ page }) => {
+		const detailPage = new ContentDetailPage(page)
+		await detailPage.goto('library', 'test-library-testing-library-content_library_001')
+
+		await detailPage.expectContentLoaded()
+
+		// Check that NPM link is visible
+		const npmLink = page.locator('a[href*="npmjs.com/package"]')
+		await expect(npmLink).toBeVisible()
+
+		// Verify the link points to the correct package
+		const href = await npmLink.getAttribute('href')
+		expect(href).toBe('https://www.npmjs.com/package/@testing-library/svelte')
+
+		// Verify link has correct attributes for external links
+		await expect(npmLink).toHaveAttribute('target', '_blank')
+		await expect(npmLink).toHaveAttribute('rel', 'noopener noreferrer')
+	})
 })

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -104,9 +104,10 @@ export const TEST_CONTENT = [
 		slug: 'test-library-testing-library',
 		description: 'Utilities for testing Svelte components',
 		metadata: {
-			npmPackage: '@testing-library/svelte',
-			githubUrl: 'https://github.com/testing-library/svelte-testing-library',
-			stars: 1500
+			npm: '@testing-library/svelte',
+			github: 'https://github.com/testing-library/svelte-testing-library',
+			stars: 1500,
+			thumbnail: 'https://opengraph.githubassets.com/test/testing-library/svelte-testing-library'
 		},
 		authorId: 'test_admin_001',
 		tags: ['tag_testing', 'tag_svelte'],


### PR DESCRIPTION
## Summary
- Automatically fetch and display NPM package links for imported libraries
- Validate package names to filter out private packages and placeholder names
- Display package links with consistent styling matching other library metadata

## Changes Made

### Backend (`github.ts`)
- Added `fetchPackageJson()` method to retrieve package.json from GitHub API
- Added `extractNpmPackageName()` with validation to filter invalid packages:
  - Checks `private: true` flag
  - Filters placeholder names (www, app, monorepo, etc.)
  - Validates NPM package name format
  - Supports scoped packages (`@scope/name`)
- Removed `guessNpmPackage()` method (replaced with actual data)

### Frontend (`Library.svelte`)
- Moved NPM link outside `fullInfo` block so it's always visible
- Added client-side validation as safety measure
- Updated styling to match other info sections (gray background, consistent spacing)
- Shows package name with "NPM:" label and link to npmjs.com

### Tests
- Updated test data to use correct schema field (`npm` instead of `npmPackage`)
- Added E2E test for NPM package link display
- Validates link points to correct package and has proper attributes

## Test Plan
- [x] Manual testing: NPM package fetching works correctly
- [x] Validation logic tested with 10 test cases (all pass)
- [x] Code compiles without errors
- [x] E2E test added for NPM link display

## Examples
- `@testing-library/svelte` → displays NPM link ✅
- `svelte-monorepo` → filtered out (monorepo suffix) ✅
- Private packages → filtered out ✅
- Repos without package.json → no error, no link ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)