### PR TITLE
Add monorepo package import support for GitHub repositories

### DIFF
--- a/src/lib/server/services/importers/github.test.ts
+++ b/src/lib/server/services/importers/github.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { GitHubImporter } from './github'
+import { ExternalContentService } from '../external-content'
+import { ContentService } from '../content'
+import { SearchService } from '../search'
+import { createTestDatabase } from '../../db/test-helpers'
+
+describe('GitHubImporter', () => {
+	let db: Database
+	let searchService: SearchService
+	let contentService: ContentService
+	let externalContentService: ExternalContentService
+	let githubImporter: GitHubImporter
+
+	// Mock GitHub API responses
+	const mockRepoResponse = {
+		id: 12345,
+		node_id: 'MDEwOlJlcG9zaXRvcnkxMjM0NQ==',
+		name: 'test-repo',
+		full_name: 'testuser/test-repo',
+		description: 'A test repository',
+		html_url: 'https://github.com/testuser/test-repo',
+		homepage: 'https://example.com',
+		language: 'TypeScript',
+		stargazers_count: 100,
+		watchers_count: 100,
+		forks_count: 10,
+		open_issues_count: 5,
+		topics: ['svelte', 'test'],
+		created_at: '2023-01-01T00:00:00Z',
+		updated_at: '2023-06-01T00:00:00Z',
+		pushed_at: '2023-06-01T00:00:00Z',
+		default_branch: 'main',
+		owner: {
+			login: 'testuser',
+			avatar_url: 'https://github.com/testuser.png',
+			html_url: 'https://github.com/testuser'
+		}
+	}
+
+	const mockPackageJson = {
+		name: '@testuser/test-package',
+		version: '1.0.0',
+		description: 'A test package from monorepo'
+	}
+
+	const mockReadme = '# Test README\n\nThis is a test.'
+
+	beforeEach(() => {
+		db = createTestDatabase()
+		searchService = new SearchService(db)
+		contentService = new ContentService(db, searchService)
+		externalContentService = new ExternalContentService(db, contentService)
+		githubImporter = new GitHubImporter(externalContentService)
+
+		// Mock global fetch
+		global.fetch = mock(async (url: string | URL) => {
+			const urlStr = url.toString()
+
+			// Mock repository endpoint
+			if (urlStr.includes('/repos/testuser/test-repo') && !urlStr.includes('/contents/')) {
+				return {
+					ok: true,
+					json: async () => mockRepoResponse
+				} as Response
+			}
+
+			// Mock README endpoint (root)
+			if (urlStr.includes('/repos/testuser/test-repo/readme')) {
+				return {
+					ok: true,
+					json: async () => ({
+						content: btoa(mockReadme),
+						encoding: 'base64'
+					})
+				} as Response
+			}
+
+			// Mock package.json endpoint (root)
+			if (urlStr.includes('/repos/testuser/test-repo/contents/package.json')) {
+				return {
+					ok: true,
+					json: async () => mockPackageJson
+				} as Response
+			}
+
+			// Mock package.json endpoint (monorepo package)
+			if (urlStr.includes('/repos/testuser/test-repo/contents/packages/kit/package.json')) {
+				return {
+					ok: true,
+					json: async () => mockPackageJson
+				} as Response
+			}
+
+			// Mock README endpoint (monorepo package)
+			if (urlStr.includes('/repos/testuser/test-repo/contents/packages/kit/README.md')) {
+				return {
+					ok: true,
+					json: async () => ({
+						content: btoa('# Package README\n\nPackage-specific readme.'),
+						encoding: 'base64'
+					})
+				} as Response
+			}
+
+			// Mock OG image
+			if (urlStr.includes('opengraph.githubassets.com')) {
+				return {
+					ok: true,
+					headers: new Headers({ 'content-type': 'image/png' }),
+					arrayBuffer: async () => new ArrayBuffer(0)
+				} as Response
+			}
+
+			return {
+				ok: false,
+				statusText: 'Not Found'
+			} as Response
+		})
+	})
+
+	afterEach(() => {
+		db.close()
+	})
+
+	describe('importRepository - Regular Repository', () => {
+		test('should import a regular repository successfully', async () => {
+			const contentId = await githubImporter.importRepository('testuser', 'test-repo')
+
+			expect(contentId).toBeTruthy()
+
+			const content = contentService.getContentById(contentId!)
+			expect(content).toBeTruthy()
+			expect(content?.title).toBe('test-repo')
+			expect(content?.description).toBe('A test repository')
+			expect(content?.type).toBe('library')
+			expect(content?.metadata.npm).toBe('@testuser/test-package')
+			expect(content?.metadata.github).toBe('https://github.com/testuser/test-repo')
+			expect(content?.metadata.stars).toBe(100)
+			expect(content?.metadata.forks).toBe(10)
+		})
+
+		test('should create correct external ID for regular repo', async () => {
+			const contentId = await githubImporter.importRepository('testuser', 'test-repo')
+
+			const existing = externalContentService.getContentByExternalId('github', 'testuser/test-repo')
+			expect(existing).toBeTruthy()
+			expect(existing?.id).toBe(contentId)
+		})
+
+		test('should update existing repository on re-import', async () => {
+			// First import
+			const firstId = await githubImporter.importRepository('testuser', 'test-repo')
+
+			// Second import
+			const secondId = await githubImporter.importRepository('testuser', 'test-repo')
+
+			expect(firstId).toBe(secondId)
+
+			// Verify only one entry exists
+			const content = contentService.getContentById(firstId!)
+			expect(content).toBeTruthy()
+		})
+	})
+
+	describe('importRepository - Monorepo Package', () => {
+		test('should import a monorepo package successfully', async () => {
+			const contentId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/kit'
+			)
+
+			expect(contentId).toBeTruthy()
+
+			const content = contentService.getContentById(contentId!)
+			expect(content).toBeTruthy()
+			expect(content?.title).toBe('@testuser/test-package')
+			expect(content?.description).toBe('A test package from monorepo')
+			expect(content?.type).toBe('library')
+		})
+
+		test('should create correct external ID for monorepo package', async () => {
+			const contentId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/kit'
+			)
+
+			const existing = externalContentService.getContentByExternalId(
+				'github',
+				'testuser/test-repo/packages/kit'
+			)
+			expect(existing).toBeTruthy()
+			expect(existing?.id).toBe(contentId)
+		})
+
+		test('should store monorepo-specific metadata', async () => {
+			const contentId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/kit'
+			)
+
+			const content = contentService.getContentById(contentId!)
+			expect(content).toBeTruthy()
+			expect(content?.metadata.packagePath).toBe('packages/kit')
+			expect(content?.metadata.packageUrl).toBe(
+				'https://github.com/testuser/test-repo/tree/main/packages/kit'
+			)
+			expect(content?.metadata.isMonorepoPackage).toBe(true)
+			expect(content?.metadata.github).toBe('https://github.com/testuser/test-repo')
+		})
+
+		test('should allow multiple packages from same repository', async () => {
+			// Import first package
+			const firstId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/kit'
+			)
+
+			// Import second package
+			const secondId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/adapter-node'
+			)
+
+			expect(firstId).toBeTruthy()
+			expect(secondId).toBeTruthy()
+			expect(firstId).not.toBe(secondId)
+
+			// Verify both exist with correct external IDs
+			const firstContent = externalContentService.getContentByExternalId(
+				'github',
+				'testuser/test-repo/packages/kit'
+			)
+			const secondContent = externalContentService.getContentByExternalId(
+				'github',
+				'testuser/test-repo/packages/adapter-node'
+			)
+
+			expect(firstContent).toBeTruthy()
+			expect(secondContent).toBeTruthy()
+			expect(firstContent?.id).toBe(firstId)
+			expect(secondContent?.id).toBe(secondId)
+		})
+
+		test('should not conflict with root repository import', async () => {
+			// Import root repository
+			const rootId = await githubImporter.importRepository('testuser', 'test-repo')
+
+			// Import package from same repository
+			const packageId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/kit'
+			)
+
+			expect(rootId).toBeTruthy()
+			expect(packageId).toBeTruthy()
+			expect(rootId).not.toBe(packageId)
+
+			// Verify both exist independently
+			const rootContent = externalContentService.getContentByExternalId('github', 'testuser/test-repo')
+			const packageContent = externalContentService.getContentByExternalId(
+				'github',
+				'testuser/test-repo/packages/kit'
+			)
+
+			expect(rootContent?.id).toBe(rootId)
+			expect(packageContent?.id).toBe(packageId)
+		})
+
+		test('should use directory name as fallback when package.json name is missing', async () => {
+			// Mock package.json without name
+			global.fetch = mock(async (url: string | URL) => {
+				const urlStr = url.toString()
+
+				if (urlStr.includes('/repos/testuser/test-repo') && !urlStr.includes('/contents/')) {
+					return { ok: true, json: async () => mockRepoResponse } as Response
+				}
+
+				if (urlStr.includes('/repos/testuser/test-repo/contents/packages/unnamed/package.json')) {
+					return {
+						ok: true,
+						json: async () => ({ version: '1.0.0' }) // No name field
+					} as Response
+				}
+
+				if (urlStr.includes('opengraph.githubassets.com')) {
+					return {
+						ok: true,
+						headers: new Headers({ 'content-type': 'image/png' }),
+						arrayBuffer: async () => new ArrayBuffer(0)
+					} as Response
+				}
+
+				return { ok: false } as Response
+			})
+
+			const contentId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/unnamed'
+			)
+
+			const content = contentService.getContentById(contentId!)
+			expect(content?.title).toBe('unnamed') // Should use directory name
+		})
+
+		test('should fallback to directory name when package.json is not found', async () => {
+			// Mock missing package.json
+			global.fetch = mock(async (url: string | URL) => {
+				const urlStr = url.toString()
+
+				if (urlStr.includes('/repos/testuser/test-repo') && !urlStr.includes('/contents/')) {
+					return { ok: true, json: async () => mockRepoResponse } as Response
+				}
+
+				if (urlStr.includes('/repos/testuser/test-repo/contents/packages/nopkg/package.json')) {
+					return { ok: false } as Response
+				}
+
+				if (urlStr.includes('opengraph.githubassets.com')) {
+					return {
+						ok: true,
+						headers: new Headers({ 'content-type': 'image/png' }),
+						arrayBuffer: async () => new ArrayBuffer(0)
+					} as Response
+				}
+
+				return { ok: false } as Response
+			})
+
+			const contentId = await githubImporter.importRepository(
+				'testuser',
+				'test-repo',
+				undefined,
+				'packages/nopkg'
+			)
+
+			const content = contentService.getContentById(contentId!)
+			expect(content?.title).toBe('nopkg') // Should use directory name as fallback
+		})
+	})
+
+	describe('NPM Package Name Extraction', () => {
+		test('should extract valid NPM package name', async () => {
+			const contentId = await githubImporter.importRepository('testuser', 'test-repo')
+			const content = contentService.getContentById(contentId!)
+
+			expect(content?.metadata.npm).toBe('@testuser/test-package')
+		})
+
+		test('should filter out monorepo placeholder names', async () => {
+			// Mock package.json with invalid name
+			global.fetch = mock(async (url: string | URL) => {
+				const urlStr = url.toString()
+
+				if (urlStr.includes('/repos/testuser/test-repo') && !urlStr.includes('/contents/')) {
+					return { ok: true, json: async () => mockRepoResponse } as Response
+				}
+
+				if (urlStr.includes('/repos/testuser/test-repo/contents/package.json')) {
+					return {
+						ok: true,
+						json: async () => ({ name: 'monorepo', private: false })
+					} as Response
+				}
+
+				if (urlStr.includes('opengraph.githubassets.com')) {
+					return {
+						ok: true,
+						headers: new Headers({ 'content-type': 'image/png' }),
+						arrayBuffer: async () => new ArrayBuffer(0)
+					} as Response
+				}
+
+				return { ok: false } as Response
+			})
+
+			const contentId = await githubImporter.importRepository('testuser', 'test-repo')
+			const content = contentService.getContentById(contentId!)
+
+			expect(content?.metadata.npm).toBeUndefined() // Should filter out 'monorepo'
+		})
+
+		test('should filter out private packages', async () => {
+			// Mock private package
+			global.fetch = mock(async (url: string | URL) => {
+				const urlStr = url.toString()
+
+				if (urlStr.includes('/repos/testuser/test-repo') && !urlStr.includes('/contents/')) {
+					return { ok: true, json: async () => mockRepoResponse } as Response
+				}
+
+				if (urlStr.includes('/repos/testuser/test-repo/contents/package.json')) {
+					return {
+						ok: true,
+						json: async () => ({ name: '@testuser/private-pkg', private: true })
+					} as Response
+				}
+
+				if (urlStr.includes('opengraph.githubassets.com')) {
+					return {
+						ok: true,
+						headers: new Headers({ 'content-type': 'image/png' }),
+						arrayBuffer: async () => new ArrayBuffer(0)
+					} as Response
+				}
+
+				return { ok: false } as Response
+			})
+
+			const contentId = await githubImporter.importRepository('testuser', 'test-repo')
+			const content = contentService.getContentById(contentId!)
+
+			expect(content?.metadata.npm).toBeUndefined() // Should filter out private packages
+		})
+	})
+})

--- a/src/lib/ui/content/Library.svelte
+++ b/src/lib/ui/content/Library.svelte
@@ -37,12 +37,15 @@
 	const isAboveFold = priority === 'high'
 	const loadingAttr = isAboveFold ? 'eager' : 'lazy'
 	const fetchPriorityAttr = isAboveFold ? 'high' : undefined
+
+	// Use packageUrl for monorepo packages, otherwise use github URL
+	const githubUrl = $derived(content.metadata.packageUrl || content.metadata.github)
 </script>
 
 <div class="relative flex h-full flex-col gap-2">
 	<!-- OG Image for GitHub repos -->
 	<a
-		href={content.metadata.github}
+		href={githubUrl}
 		target="_blank"
 		rel="noopener noreferrer"
 		data-testid="library-thumbnail-link"

--- a/src/routes/(admin)/admin/bulk-import/+page.svelte
+++ b/src/routes/(admin)/admin/bulk-import/+page.svelte
@@ -52,6 +52,16 @@
 	<div>
 		<h1 class="text-2xl font-bold">Bulk Import</h1>
 		<p class="mt-2 text-gray-600">Import multiple YouTube videos or GitHub repositories at once</p>
+		<div class="mt-4 rounded-md bg-blue-50 p-4">
+			<h3 class="text-sm font-semibold text-blue-900">Monorepo Support</h3>
+			<p class="mt-1 text-sm text-blue-700">
+				You can now import individual packages from monorepos by specifying a path:
+			</p>
+			<ul class="mt-2 space-y-1 text-sm text-blue-700">
+				<li><code class="rounded bg-blue-100 px-1 py-0.5">owner/repo/packages/kit</code> - Short format</li>
+				<li><code class="rounded bg-blue-100 px-1 py-0.5">https://github.com/owner/repo/tree/main/packages/kit</code> - Full URL</li>
+			</ul>
+		</div>
 	</div>
 
 	<div class="max-w-4xl">
@@ -62,9 +72,10 @@
 					label="URLs (one per line)"
 					placeholder="https://youtube.com/watch?v=dQw4w9WgXcQ
 https://github.com/sveltejs/svelte
-https://youtu.be/abc123
+https://github.com/sveltejs/kit/tree/main/packages/kit
+sveltejs/kit/packages/adapter-node
 owner/repo-name"
-					description="Enter YouTube URLs, video IDs, GitHub URLs, or owner/repo format. Maximum 50 URLs."
+					description="Enter YouTube URLs, video IDs, GitHub URLs, or owner/repo/path format for monorepo packages. Maximum 50 URLs."
 					rows={10}
 				/>
 

--- a/src/routes/(admin)/admin/external-content/+page.svelte
+++ b/src/routes/(admin)/admin/external-content/+page.svelte
@@ -98,8 +98,8 @@
 						<Input
 							name="url"
 							label="Content URL"
-							placeholder="https://youtube.com/watch?v=... or https://github.com/owner/repo"
-							description={placeholder() || 'Paste a YouTube video URL or GitHub repository URL'}
+							placeholder="https://youtube.com/watch?v=... or https://github.com/owner/repo or owner/repo/packages/kit"
+							description={placeholder() || 'Paste a YouTube video URL, GitHub repository URL, or monorepo package path'}
 						/>
 
 						{#if detectContentType($importForm.url)}
@@ -155,7 +155,7 @@
 						<p class="text-xs text-gray-700">
 							<strong>Supported formats:</strong>
 							<br />• YouTube: Full URLs, short URLs (youtu.be), or video IDs
-							<br />• GitHub: Full URLs or owner/repo format
+							<br />• GitHub: Full URLs, owner/repo, or owner/repo/path for monorepo packages
 						</p>
 					</div>
 				</div>

--- a/src/routes/(api)/api/bulk-import/README.md
+++ b/src/routes/(api)/api/bulk-import/README.md
@@ -1,6 +1,6 @@
 # Bulk Import API
 
-The bulk import endpoint allows you to import multiple YouTube videos or GitHub repositories in a single request.
+The bulk import endpoint allows you to import multiple YouTube videos or GitHub repositories (including monorepo packages) in a single request.
 
 ## Authentication
 

--- a/src/routes/(api)/api/bulk-import/README.md
+++ b/src/routes/(api)/api/bulk-import/README.md
@@ -39,8 +39,10 @@ Content-Type: application/json
 	"urls": [
 		"https://www.youtube.com/watch?v=VIDEO_ID",
 		"https://github.com/owner/repo",
+		"https://github.com/owner/repo/tree/main/packages/kit",
 		"VIDEO_ID",
-		"owner/repo"
+		"owner/repo",
+		"owner/repo/packages/kit"
 	],
 	"options": {
 		"skipExisting": true,
@@ -92,6 +94,51 @@ curl -X POST https://sveltesociety.dev/api/bulk-import \
       "https://www.youtube.com/watch?v=8KuO4r5CHjM",
       "https://github.com/sveltejs/svelte",
       "https://github.com/sveltejs/kit"
+    ]
+  }'
+```
+
+## Monorepo Support
+
+The API now supports importing individual packages from monorepos. You can specify a package path in the following formats:
+
+### Supported Formats
+
+1. **Full GitHub URL with path:**
+   ```
+   https://github.com/sveltejs/kit/tree/main/packages/kit
+   ```
+
+2. **Short format (owner/repo/path):**
+   ```
+   sveltejs/kit/packages/kit
+   ```
+
+3. **Traditional format (for non-monorepos):**
+   ```
+   sveltejs/kit
+   ```
+
+### How It Works
+
+- If a package path is provided, the importer will:
+  - Fetch `package.json` from the specified directory
+  - Look for a README in that directory (falls back to root README)
+  - Use the package name and description from `package.json`
+  - Create a unique external ID: `owner/repo/path`
+  - Link to the package subdirectory on GitHub
+
+### Example
+
+```bash
+curl -X POST https://sveltesociety.dev/api/bulk-import \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "urls": [
+      "sveltejs/kit/packages/kit",
+      "sveltejs/kit/packages/adapter-auto",
+      "sveltejs/kit/packages/adapter-node"
     ]
   }'
 ```

--- a/src/routes/(app)/(public)/submit/+page.svelte
+++ b/src/routes/(app)/(public)/submit/+page.svelte
@@ -199,10 +199,10 @@
 			{/if}
 		{:else if $formData.type === 'library'}
 			<Input
-				placeholder="username/repository"
+				placeholder="username/repository or username/repository/packages/name"
 				name="github_repo"
 				label="GitHub Repository"
-				description="GitHub repository (required for libraries)"
+				description="GitHub repository or monorepo package path (required for libraries)"
 				data-testid="library-github-input"
 			/>
 

--- a/src/routes/(app)/(public)/submit/schema.ts
+++ b/src/routes/(app)/(public)/submit/schema.ts
@@ -32,6 +32,15 @@ const librarySchema = baseSchema.extend({
 	github_repo: z
 		.string()
 		.min(1, { message: 'GitHub repository is required for library submissions' })
+		.refine(
+			(val) => {
+				// Accept: owner/repo, owner/repo/path, or full GitHub URLs
+				const urlPattern = /^https?:\/\/github\.com\/([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_.]+)(?:\/tree\/[^/]+\/(.+))?/
+				const repoPattern = /^([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_.]+)(?:\/(.+))?$/
+				return urlPattern.test(val) || repoPattern.test(val)
+			},
+			{ message: 'Must be a valid GitHub repository (owner/repo or owner/repo/path for monorepos)' }
+		)
 })
 
 const recipeSchema = baseSchema.extend({

--- a/tests/e2e/admin/bulk-import.spec.ts
+++ b/tests/e2e/admin/bulk-import.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test'
+import { setupDatabaseIsolation } from '../../helpers/database-isolation'
+import { loginAs } from '../../helpers/auth'
+
+test.describe('Bulk Import', () => {
+	test.beforeEach(async ({ page }) => {
+		await setupDatabaseIsolation(page)
+		await loginAs(page, 'admin')
+	})
+
+	test('displays monorepo support information', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		// Check for monorepo support section
+		await expect(page.getByText('Monorepo Support')).toBeVisible()
+		await expect(page.getByText('owner/repo/packages/kit')).toBeVisible()
+	})
+
+	test('accepts standard GitHub repository format', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		const textarea = page.getByTestId('textarea-urls')
+		await expect(textarea).toBeVisible()
+
+		// Verify placeholder includes monorepo examples
+		const placeholder = await textarea.getAttribute('placeholder')
+		expect(placeholder).toContain('packages/kit')
+	})
+
+	test('API accepts monorepo package path in short format', async ({ page }) => {
+		// Navigate to ensure session is established
+		await page.goto('/admin/bulk-import')
+
+		// Test the API directly with monorepo path
+		const response = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: ['sveltejs/kit/packages/kit'],
+				options: {
+					skipExisting: false,
+					batchSize: 1
+				}
+			}
+		})
+
+		expect(response.ok()).toBeTruthy()
+		const result = await response.json()
+
+		expect(result.success).toBe(true)
+		expect(result.summary.total).toBe(1)
+		expect(result.results[0].type).toBe('github')
+	})
+
+	test('API accepts monorepo package path in URL format', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		// Test the API with full GitHub URL including path
+		const response = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: ['https://github.com/sveltejs/kit/tree/main/packages/kit'],
+				options: {
+					skipExisting: false,
+					batchSize: 1
+				}
+			}
+		})
+
+		expect(response.ok()).toBeTruthy()
+		const result = await response.json()
+
+		expect(result.success).toBe(true)
+		expect(result.summary.total).toBe(1)
+		expect(result.results[0].type).toBe('github')
+	})
+
+	test('creates unique entries for different packages from same repo', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		// Import two different packages from the same monorepo
+		const response = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: [
+					'sveltejs/kit/packages/kit',
+					'sveltejs/kit/packages/adapter-node'
+				],
+				options: {
+					skipExisting: false,
+					batchSize: 2
+				}
+			}
+		})
+
+		expect(response.ok()).toBeTruthy()
+		const result = await response.json()
+
+		expect(result.success).toBe(true)
+		expect(result.summary.total).toBe(2)
+		expect(result.summary.successful).toBe(2)
+
+		// Both should be GitHub imports
+		expect(result.results[0].type).toBe('github')
+		expect(result.results[1].type).toBe('github')
+
+		// Should create different content entries
+		expect(result.results[0].contentId).not.toBe(result.results[1].contentId)
+	})
+
+	test('handles skipExisting for monorepo packages', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		// First import
+		const firstResponse = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: ['sveltejs/kit/packages/kit'],
+				options: {
+					skipExisting: false,
+					batchSize: 1
+				}
+			}
+		})
+
+		expect(firstResponse.ok()).toBeTruthy()
+		const firstResult = await firstResponse.json()
+		const contentId = firstResult.results[0].contentId
+
+		// Second import with skipExisting=true
+		const secondResponse = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: ['sveltejs/kit/packages/kit'],
+				options: {
+					skipExisting: true,
+					batchSize: 1
+				}
+			}
+		})
+
+		expect(secondResponse.ok()).toBeTruthy()
+		const secondResult = await secondResponse.json()
+
+		expect(secondResult.summary.skipped).toBe(1)
+		expect(secondResult.results[0].error).toContain('Already imported')
+		expect(secondResult.results[0].contentId).toBe(contentId)
+	})
+
+	test('can import both regular repo and monorepo packages in same request', async ({ page }) => {
+		await page.goto('/admin/bulk-import')
+
+		const response = await page.request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: [
+					'sveltejs/svelte',  // Regular repo
+					'sveltejs/kit/packages/kit',  // Monorepo package
+				],
+				options: {
+					skipExisting: false,
+					batchSize: 2
+				}
+			}
+		})
+
+		expect(response.ok()).toBeTruthy()
+		const result = await response.json()
+
+		expect(result.success).toBe(true)
+		expect(result.summary.total).toBe(2)
+		expect(result.summary.byType.github).toBe(2)
+
+		// Both should succeed
+		expect(result.results[0].success).toBe(true)
+		expect(result.results[1].success).toBe(true)
+	})
+
+	test('requires authentication for bulk import', async ({ page, request }) => {
+		// Create a new context without authentication
+		const response = await request.post('/api/bulk-import', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				urls: ['sveltejs/kit/packages/kit'],
+			}
+		})
+
+		expect(response.status()).toBe(401)
+	})
+})

--- a/tests/e2e/content/submit-library.spec.ts
+++ b/tests/e2e/content/submit-library.spec.ts
@@ -45,4 +45,32 @@ test.describe('Submit Library', () => {
 		await submitPage.submit()
 		await submitPage.expectValidationError('Description must be at least 10 characters long')
 	})
+
+	test('can submit a monorepo package with path', async ({ page }) => {
+		const submitPage = new SubmitPage(page)
+		await submitPage.goto()
+
+		await submitPage.fillLibraryForm({
+			githubRepo: 'sveltejs/kit/packages/kit',
+			description: 'The fastest way to build Svelte apps - SvelteKit package from monorepo.',
+			tags: ['svelte']
+		})
+
+		await submitPage.submit()
+		await submitPage.expectSuccessRedirect()
+	})
+
+	test('can submit a monorepo package with full GitHub URL', async ({ page }) => {
+		const submitPage = new SubmitPage(page)
+		await submitPage.goto()
+
+		await submitPage.fillLibraryForm({
+			githubRepo: 'https://github.com/sveltejs/kit/tree/main/packages/adapter-node',
+			description: 'Adapter for SvelteKit apps that generates a standalone Node server.',
+			tags: ['svelte']
+		})
+
+		await submitPage.submit()
+		await submitPage.expectSuccessRedirect()
+	})
 })


### PR DESCRIPTION
## Summary

This PR adds support for importing individual packages from monorepo repositories, in addition to the existing root-level repository imports. Users can now specify package paths in all three import routes.

## Changes

### Core Functionality
- **GitHub Importer Service**: Added `packagePath` parameter and enhanced metadata handling
  - External IDs now distinguish between repos and packages: `owner/repo` vs `owner/repo/path`
  - Title uses package.json name for monorepo packages, falls back to directory name
  - README fetching tries package directory first, falls back to root
  - Stores monorepo-specific metadata: `packagePath`, `packageUrl`, `isMonorepoPackage`

### Import Routes (all support monorepo paths)
- `/api/bulk-import` - Bulk import API
- `/submit` - Public submission form
- `/admin/external-content` - Admin import interface

### UI Improvements
- Library card thumbnails link to package subdirectory for monorepo packages
- Updated placeholders and help text with monorepo examples
- Added monorepo support documentation banner in bulk import UI

## Supported Formats

All import routes now accept:
- Regular repos: `owner/repo` or `https://github.com/owner/repo`
- Monorepo packages: `owner/repo/path/to/package` or `https://github.com/owner/repo/tree/branch/path/to/package`

## Examples

- `sveltejs/kit/packages/kit`
- `sveltejs/kit/packages/adapter-node`
- `https://github.com/sveltejs/kit/tree/main/packages/adapter-vercel`

## Testing

### Unit Tests (13 tests - all passing)
- Regular repository import (3 tests)
- Monorepo package import (6 tests)
- NPM package name extraction and validation (3 tests)
- Edge cases: missing package.json, invalid names, private packages

### E2E Tests (10 tests - all passing)
- Bulk import with monorepo support (8 tests)
- Submit form monorepo submission (2 tests)

**Total: 23 tests covering monorepo functionality**

## Implementation Notes

- Multiple packages from the same repository can coexist as separate content items
- Root repository and individual packages can be imported independently
- Deduplication works correctly using hierarchical external IDs
- NPM package names are validated and filtered (excludes private and placeholder names)

## Test Plan

Run the test suite:
```bash
bun test src/lib/server/services/importers/github.test.ts
bun run test:integration tests/e2e/admin/bulk-import.spec.ts
bun run test:integration tests/e2e/content/submit-library.spec.ts
```

Try importing:
1. Regular repo: `sveltejs/svelte`
2. Monorepo package: `sveltejs/kit/packages/kit`
3. Full URL: `https://github.com/sveltejs/kit/tree/main/packages/adapter-node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)