### PR TITLE
Update collection children cards text to say submitted by

### DIFF
--- a/src/lib/ui/content/Collection.svelte
+++ b/src/lib/ui/content/Collection.svelte
@@ -31,7 +31,7 @@
 
 				<div class="mb-1 flex text-xs text-gray-500">
 					<span class="mr-0.5 font-semibold capitalize">{child?.type || 'content'}</span>
-					by {getAuthor(child)} •
+					submitted by {getAuthor(child)} •
 					{child?.published_at ? formatRelativeDate(child.published_at) : 'Unknown date'}
 				</div>
 			</a>


### PR DESCRIPTION
Update collection children cards to display "X submitted by Y" instead of "X by Y" for better clarity on the authorship context.

This change improves the user experience by making it clearer that the content was submitted by the author, not just created by them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)