### PR TITLE
Increase fetch limits for admin and content feed

### DIFF
--- a/src/routes/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(admin)/admin/users/+page.server.ts
@@ -3,7 +3,7 @@ import { fail, redirect } from '@sveltejs/kit'
 
 export const load = (async ({ url, locals }) => {
 	const page = parseInt(url.searchParams.get('page') || '1', 10)
-	const perPage = 10
+	const perPage = 25
 	const offset = (page - 1) * perPage
 
 	const users = locals.userService.getUsers({ limit: perPage, offset })

--- a/src/routes/(app)/(public)/[...type]/+page.server.ts
+++ b/src/routes/(app)/(public)/[...type]/+page.server.ts
@@ -66,7 +66,7 @@ export const load: PageServerLoad = async ({ url, locals, params }) => {
 
 	// Handle pagination
 	const page = parseInt(url.searchParams.get('page') || '1', 10)
-	const perPage = 15 // Should match the default limit in search service
+	const perPage = 30 // Should match the default limit in search service
 	const offset = (page - 1) * perPage
 
 	// Handle rest parameter - params.type can be an array like ['recipe'] or undefined


### PR DESCRIPTION
Increases pagination limits to improve browsing experience.

- Admin users dashboard: 10 → 25 users per page
- Content feed route: 15 → 30 items per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)