### PR TITLE
Fix ContentCard save button and restore interact action

### DIFF
--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -118,6 +118,7 @@
 			</button>
 			<button
 				title={content.saved ? 'Unsave' : 'Save'}
+				data-sveltekit-keepfocus
 				disabled={!page.data.user || submitting}
 				aria-label="Save {content.title}"
 				name="type"

--- a/src/routes/(app)/(public)/[...type]/+page.server.ts
+++ b/src/routes/(app)/(public)/[...type]/+page.server.ts
@@ -1,0 +1,31 @@
+import { fail } from '@sveltejs/kit'
+import type { Actions } from './$types'
+
+export const actions = {
+	interact: async ({ request, locals }) => {
+		if (!locals.user) return
+		const data = await request.formData()
+		const type = data.get('type') as 'like' | 'save'
+		const contentId = data.get('id') as string
+
+		try {
+			const result = locals.interactionsService.toggleInteraction(type, locals.user.id, contentId)
+
+			const currentContentData = locals.searchService.getContentById(contentId)!
+			if (result.action === 'add') {
+				locals.searchService.update(contentId, {
+					...currentContentData,
+					...{ [type + 's']: currentContentData[type + 's'] + 1 }
+				})
+			} else {
+				locals.searchService.update(contentId, {
+					...currentContentData,
+					...{ [type + 's']: currentContentData[type + 's'] - 1 }
+				})
+			}
+			return { success: true }
+		} catch (error) {
+			return fail(500, { message: 'Server error' })
+		}
+	}
+} satisfies Actions

--- a/tests/e2e/public/content-interactions.spec.ts
+++ b/tests/e2e/public/content-interactions.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from '@playwright/test'
+import { ContentDetailPage } from '../../pages'
+import { setupDatabaseIsolation } from '../../helpers/database-isolation'
+import { loginAs } from '../../helpers/auth'
+
+test.describe('Content Interactions (Like/Save)', () => {
+	test.beforeEach(async ({ page }) => {
+		await setupDatabaseIsolation(page)
+	})
+
+	test.describe('Unauthenticated Users', () => {
+		test('like and save buttons are disabled when not logged in', async ({ page }) => {
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Buttons should be visible but disabled
+			await expect(detailPage.likeButton).toBeVisible()
+			await expect(detailPage.saveButton).toBeVisible()
+			await expect(detailPage.likeButton).toBeDisabled()
+			await expect(detailPage.saveButton).toBeDisabled()
+		})
+
+		test('like and save buttons have correct initial counts', async ({ page }) => {
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
+
+			await detailPage.expectContentLoaded()
+
+			const likeCount = await detailPage.getLikeCount()
+			const saveCount = await detailPage.getSaveCount()
+
+			// Verify counts are numbers >= 0
+			expect(likeCount).toBeGreaterThanOrEqual(0)
+			expect(saveCount).toBeGreaterThanOrEqual(0)
+		})
+	})
+
+	test.describe('Authenticated Users - Like Functionality', () => {
+		test('can like content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Get initial like count and state
+			const initialLikeCount = await detailPage.getLikeCount()
+			const initiallyLiked = await detailPage.isLiked()
+
+			// Like the content
+			await detailPage.like()
+
+			// Wait for the interaction to complete
+			await page.waitForTimeout(500)
+
+			// Verify like count increased by 1
+			const newLikeCount = await detailPage.getLikeCount()
+			if (!initiallyLiked) {
+				expect(newLikeCount).toBe(initialLikeCount + 1)
+			}
+
+			// Verify button state changed
+			const nowLiked = await detailPage.isLiked()
+			expect(nowLiked).toBe(!initiallyLiked)
+		})
+
+		test('can unlike content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
+
+			await detailPage.expectContentLoaded()
+
+			// First, like the content
+			await detailPage.like()
+			await page.waitForTimeout(500)
+
+			const likeCountAfterLike = await detailPage.getLikeCount()
+			const likedState = await detailPage.isLiked()
+			expect(likedState).toBe(true)
+
+			// Now unlike it
+			await detailPage.like()
+			await page.waitForTimeout(500)
+
+			// Verify like count decreased by 1
+			const finalLikeCount = await detailPage.getLikeCount()
+			expect(finalLikeCount).toBe(likeCountAfterLike - 1)
+
+			// Verify button state changed
+			const finalLikedState = await detailPage.isLiked()
+			expect(finalLikedState).toBe(false)
+		})
+
+		test('like button has data-sveltekit-keepfocus attribute', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('recipe', 'test-recipe-counter-component-content_recipe_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Verify like button has the data-sveltekit-keepfocus attribute to prevent focus loss
+			await expect(detailPage.likeButton).toHaveAttribute('data-sveltekit-keepfocus')
+		})
+	})
+
+	test.describe('Authenticated Users - Save Functionality', () => {
+		test('can save content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('video', 'test-video-svelte-5-intro-content_video_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Get initial save count and state
+			const initialSaveCount = await detailPage.getSaveCount()
+			const initiallySaved = await detailPage.isSaved()
+
+			// Save the content
+			await detailPage.save()
+
+			// Wait for the interaction to complete
+			await page.waitForTimeout(500)
+
+			// Verify save count increased by 1
+			const newSaveCount = await detailPage.getSaveCount()
+			if (!initiallySaved) {
+				expect(newSaveCount).toBe(initialSaveCount + 1)
+			}
+
+			// Verify button state changed
+			const nowSaved = await detailPage.isSaved()
+			expect(nowSaved).toBe(!initiallySaved)
+		})
+
+		test('can unsave content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('video', 'test-video-svelte-5-intro-content_video_001')
+
+			await detailPage.expectContentLoaded()
+
+			// First, save the content
+			await detailPage.save()
+			await page.waitForTimeout(500)
+
+			const saveCountAfterSave = await detailPage.getSaveCount()
+			const savedState = await detailPage.isSaved()
+			expect(savedState).toBe(true)
+
+			// Now unsave it
+			await detailPage.save()
+			await page.waitForTimeout(500)
+
+			// Verify save count decreased by 1
+			const finalSaveCount = await detailPage.getSaveCount()
+			expect(finalSaveCount).toBe(saveCountAfterSave - 1)
+
+			// Verify button state changed
+			const finalSavedState = await detailPage.isSaved()
+			expect(finalSavedState).toBe(false)
+		})
+
+		test('save button has data-sveltekit-keepfocus attribute', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('video', 'test-video-svelte-5-intro-content_video_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Verify save button has the data-sveltekit-keepfocus attribute to prevent focus loss
+			await expect(detailPage.saveButton).toHaveAttribute('data-sveltekit-keepfocus')
+		})
+	})
+
+	test.describe('Cross-Content Type Interactions', () => {
+		test('can interact with library content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('library', 'test-library-testing-library-content_library_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Test both like and save
+			await detailPage.like()
+			await page.waitForTimeout(500)
+			expect(await detailPage.isLiked()).toBe(true)
+
+			await detailPage.save()
+			await page.waitForTimeout(500)
+			expect(await detailPage.isSaved()).toBe(true)
+		})
+
+		test('can interact with announcement content', async ({ page }) => {
+			await loginAs(page, 'viewer')
+			const detailPage = new ContentDetailPage(page)
+			await detailPage.goto('announcement', 'test-announcement-svelte-5-released-content_announcement_001')
+
+			await detailPage.expectContentLoaded()
+
+			// Test both like and save
+			await detailPage.like()
+			await page.waitForTimeout(500)
+			expect(await detailPage.isLiked()).toBe(true)
+
+			await detailPage.save()
+			await page.waitForTimeout(500)
+			expect(await detailPage.isSaved()).toBe(true)
+		})
+	})
+
+})


### PR DESCRIPTION
## Summary
Fixed two critical issues that prevented the save/like functionality from working on ContentCard components.

## Changes

### 1. Restored Missing Interact Form Action
The `interact` action was accidentally removed in PR #873 when migrating to remote functions. This PR restores it:
- Created `src/routes/(app)/(public)/[...type]/+page.server.ts` with the interact action handler
- Handles both `like` and `save` interactions
- Updates search index when interactions occur to keep counts in sync

### 2. Fixed Save Button
- Added missing `data-sveltekit-keepfocus` attribute to save button (line 121)
- Save button now matches like button behavior
- Prevents focus loss during form submission

### 3. Comprehensive E2E Test Coverage
Created new test file `tests/e2e/public/content-interactions.spec.ts` with 10 tests:
- ✅ Unauthenticated users (buttons disabled, correct counts)
- ✅ Like functionality (like, unlike, keepfocus attribute)
- ✅ Save functionality (save, unsave, keepfocus attribute)  
- ✅ Cross-content type interactions (library, announcement)

All tests passing! 🎉

## Test Results
```
  10 passed (18.0s)
```

## Files Changed
- `src/lib/ui/ContentCard.svelte` - Added `data-sveltekit-keepfocus` to save button
- `src/routes/(app)/(public)/[...type]/+page.server.ts` - New file with interact action
- `tests/e2e/public/content-interactions.spec.ts` - New comprehensive test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)