### PR TITLE
Remove unused code and exports

### DIFF
--- a/src/routes/(admin)/admin/announcements/schema.ts
+++ b/src/routes/(admin)/admin/announcements/schema.ts
@@ -8,5 +8,3 @@ export const placementSchema = z.object({
 	priority: z.number().int().min(0).default(0),
 	is_active: z.boolean().default(true)
 })
-
-export type PlacementFormData = z.infer<typeof placementSchema>

--- a/src/routes/(app)/(public)/submit/schema.ts
+++ b/src/routes/(app)/(public)/submit/schema.ts
@@ -6,7 +6,7 @@ const types = {
 	library: 'Library'
 } as const
 
-export type ContentType = keyof typeof types
+type ContentType = keyof typeof types
 
 export const options = Object.entries(types).map(([value, label]) => ({
 	value,
@@ -50,5 +50,3 @@ const recipeSchema = baseSchema.extend({
 })
 
 export const schema = z.discriminatedUnion('type', [videoSchema, librarySchema, recipeSchema])
-
-export type SubmissionData = z.infer<typeof schema>

--- a/src/routes/og-image/[slug]/icons.ts
+++ b/src/routes/og-image/[slug]/icons.ts
@@ -49,7 +49,7 @@ export const BUG_ICON = `data:image/svg+xml;base64,${Buffer.from(
  */
 
 // Video icon
-export const VIDEO_ICON = `data:image/svg+xml;base64,${Buffer.from(
+const VIDEO_ICON = `data:image/svg+xml;base64,${Buffer.from(
 	`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="m22 8-6 4 6 4V8Z"></path>
 		<rect width="14" height="12" x="2" y="6" rx="2" ry="2"></rect>
@@ -57,7 +57,7 @@ export const VIDEO_ICON = `data:image/svg+xml;base64,${Buffer.from(
 ).toString('base64')}`
 
 // Library/Package icon
-export const LIBRARY_ICON = `data:image/svg+xml;base64,${Buffer.from(
+const LIBRARY_ICON = `data:image/svg+xml;base64,${Buffer.from(
 	`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="M16.5 9.4 7.55 4.24"></path>
 		<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
@@ -67,7 +67,7 @@ export const LIBRARY_ICON = `data:image/svg+xml;base64,${Buffer.from(
 ).toString('base64')}`
 
 // Recipe/Document icon
-export const RECIPE_ICON = `data:image/svg+xml;base64,${Buffer.from(
+const RECIPE_ICON = `data:image/svg+xml;base64,${Buffer.from(
 	`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path>
 		<polyline points="14 2 14 8 20 8"></polyline>
@@ -78,7 +78,7 @@ export const RECIPE_ICON = `data:image/svg+xml;base64,${Buffer.from(
 ).toString('base64')}`
 
 // Announcement/Megaphone icon
-export const ANNOUNCEMENT_ICON = `data:image/svg+xml;base64,${Buffer.from(
+const ANNOUNCEMENT_ICON = `data:image/svg+xml;base64,${Buffer.from(
 	`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="m3 11 18-5v12L3 14v-3z"></path>
 		<path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"></path>
@@ -86,7 +86,7 @@ export const ANNOUNCEMENT_ICON = `data:image/svg+xml;base64,${Buffer.from(
 ).toString('base64')}`
 
 // Collection/Book icon
-export const COLLECTION_ICON = `data:image/svg+xml;base64,${Buffer.from(
+const COLLECTION_ICON = `data:image/svg+xml;base64,${Buffer.from(
 	`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
 		<path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>

--- a/src/routes/og-image/[slug]/types.ts
+++ b/src/routes/og-image/[slug]/types.ts
@@ -17,7 +17,7 @@ export interface SatoriNode {
 	}
 }
 
-export interface BaseContentData {
+interface BaseContentData {
 	title: string
 	type: string
 	description?: string

--- a/src/routes/og-image/[slug]/utils.ts
+++ b/src/routes/og-image/[slug]/utils.ts
@@ -8,7 +8,7 @@ import { OG_IMAGE_COLORS, SVELTE_SOCIETY_LOGO_BASE64 } from './constants'
 /**
  * Creates the orange accent bar at the top of the image
  */
-export function createAccentBar(): SatoriNode {
+function createAccentBar(): SatoriNode {
 	return {
 		type: 'div',
 		props: {

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -35,17 +35,6 @@ export async function loginAs(page: Page, role: 'admin' | 'viewer'): Promise<voi
 }
 
 /**
- * Logs out the current user by clearing the session cookie.
- *
- * @param page - Playwright page object
- * @example
- * await logout(page)
- */
-export async function logout(page: Page): Promise<void> {
-	await page.context().clearCookies()
-}
-
-/**
  * Checks if a user is currently logged in by looking for the session cookie.
  *
  * @param page - Playwright page object

--- a/tests/helpers/database-isolation.ts
+++ b/tests/helpers/database-isolation.ts
@@ -79,38 +79,6 @@ function getCallerTestFileIdentifier(): string {
 	throw new Error('Unable to find .spec.ts file in stack trace. Please provide testFileName manually.')
 }
 
-/**
- * Sets up database isolation at the context level (recommended).
- * This ensures all pages in the context use the same isolated database.
- *
- * @param context - Playwright browser context
- * @param testFileName - Name of the test file (e.g., 'content-detail', 'browse-content')
- *
- * @example
- * test.use({
- *   storageState: async ({ browser }, use) => {
- *     const context = await browser.newContext()
- *     await setupDatabaseIsolationForContext(context, 'content-detail')
- *     // ... rest of test
- *   }
- * })
- */
-export async function setupDatabaseIsolationForContext(
-	context: BrowserContext,
-	testFileName: string
-): Promise<void> {
-	await context.addCookies([
-		{
-			name: 'test_db',
-			value: testFileName,
-			domain: 'localhost',
-			path: '/',
-			httpOnly: false,
-			secure: false,
-			sameSite: 'Lax'
-		}
-	])
-}
 
 /**
  * Extracts a test file identifier from the file path.

--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -4,8 +4,8 @@
  */
 
 import fs from 'fs'
-import path from 'path'
 import { globSync } from 'glob'
+import { getTestFileIdentifier } from '../helpers/database-isolation'
 
 export default async function globalSetup() {
 	console.log('🚀 Global test setup starting...\n')
@@ -59,30 +59,6 @@ export default async function globalSetup() {
 
 	console.log(`\n✅ Pre-created ${created} isolated test database(s)`)
 	console.log('   Each test file will use its own database copy for perfect isolation\n')
-}
-
-/**
- * Extracts a test file identifier from the file path.
- * Uses the full relative path from tests/e2e with slashes replaced by hyphens.
- * This must match the identifier used in setupDatabaseIsolation() calls.
- *
- * @param filePath - Full path to the test file
- * @returns A path-based identifier (e.g., 'public-content-detail', 'admin-moderation')
- */
-function getTestFileIdentifier(filePath: string): string {
-	// Normalize the path to use forward slashes
-	const normalized = filePath.replace(/\\/g, '/')
-
-	// Extract just the e2e path portion (e.g., 'public/content-detail.spec.ts')
-	const e2eMatch = normalized.match(/tests\/e2e\/(.+\.spec\.ts)/)
-	const relativePath = e2eMatch ? e2eMatch[1] : path.basename(filePath)
-
-	// Remove .spec.ts extension and replace slashes with hyphens
-	// e.g., 'public/content-detail.spec.ts' → 'public-content-detail'
-	// e.g., 'admin/moderation.spec.ts' → 'admin-moderation'
-	return relativePath
-		.replace(/\.spec\.ts$/, '')
-		.replace(/\//g, '-')
 }
 
 // Run when executed directly


### PR DESCRIPTION
## Summary

This PR removes unused code and exports identified by running `knip` on the codebase.

## Changes

### OG Image Generation
- Changed `VIDEO_ICON`, `LIBRARY_ICON`, `RECIPE_ICON`, `ANNOUNCEMENT_ICON`, `COLLECTION_ICON` from exported to internal constants in `icons.ts` (only used within the file)
- Changed `createAccentBar` from exported to internal function in `utils.ts` (only used within the file)
- Changed `BaseContentData` from exported to internal interface in `types.ts` (only used as base for other interfaces)

### Schema Files
- Removed unused `PlacementFormData` type export from announcements schema
- Changed `ContentType` from exported to internal type in submit schema
- Removed unused `SubmissionData` type export from submit schema

### Test Helpers
- Removed unused `logout` function from auth helpers
- Removed unused `setupDatabaseIsolationForContext` function from database-isolation helpers
- Consolidated duplicate `getTestFileIdentifier` function by importing from shared helper

## Impact

- **No breaking changes** - All removed exports were genuinely unused
- Reduces bundle size slightly by removing dead code
- Improves code maintainability by removing clutter
- Eliminates code duplication in test helpers

## Test Plan

- All existing tests should pass
- No functionality changes, only removing unused code

🤖 Generated with [Claude Code](https://claude.com/claude-code)