### PR TITLE
Fix submit page schema shape error with z.url()

### DIFF
--- a/src/routes/(app)/(public)/submit/schema.ts
+++ b/src/routes/(app)/(public)/submit/schema.ts
@@ -24,7 +24,7 @@ const baseSchema = z.object({
 
 const videoSchema = baseSchema.extend({
 	type: z.literal('video'),
-	url: z.url({ message: 'Please enter a valid YouTube URL' })
+	url: z.string().url({ message: 'Please enter a valid YouTube URL' })
 })
 
 const librarySchema = baseSchema.extend({


### PR DESCRIPTION
## Summary
- Replace `z.url()` with `z.string().url()` in the submit page schema for sveltekit-superforms compatibility
- Fixes production 500 error: "No shape could be created for schema" when accessing `/submit`

## Root Cause
The `z.url()` function is a Zod 4-specific shorthand that the sveltekit-superforms `zod4` adapter's `schemaShape` function cannot properly introspect. This causes the adapter to throw an error when trying to determine the form field shape.

## Fix
Both `z.url()` and `z.string().url()` validate URLs identically, but `z.string().url()` creates a schema structure that sveltekit-superforms can understand.

## Test plan
- [ ] Verify `/submit` page loads without 500 error
- [ ] Test submitting a video with a YouTube URL validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)