### PR TITLE
Replace Author dropdown with searchable autocomplete

### DIFF
--- a/src/lib/ui/form/AutoComplete.svelte
+++ b/src/lib/ui/form/AutoComplete.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import type { SuperForm } from 'sveltekit-superforms'
+	import { Control, Description, Field, FieldErrors, Label } from 'formsnap'
+	import { getContext } from 'svelte'
+	import { Combobox } from 'bits-ui'
+
+	interface Option {
+		value: string
+		label: string
+		avatar?: string
+	}
+
+	interface AutoCompleteProps {
+		label?: string
+		description?: string
+		placeholder?: string
+		name: string
+		disabled?: boolean
+		options: Option[]
+		testId?: string
+	}
+
+	let {
+		name,
+		label,
+		description,
+		placeholder = 'Search...',
+		options,
+		disabled = false,
+		testId
+	}: AutoCompleteProps = $props()
+
+	const computedTestId = $derived(testId || `autocomplete-${name}`)
+
+	const form: SuperForm<Record<string, string>, any> = getContext('form')
+	const { form: formData } = form
+
+	let searchValue = $state('')
+	let open = $state(false)
+
+	const filteredOptions = $derived(
+		searchValue === ''
+			? options
+			: options.filter((option) =>
+					option.label.toLowerCase().includes(searchValue.toLowerCase())
+				)
+	)
+
+	function handleOpenChange(isOpen: boolean) {
+		open = isOpen
+		if (!isOpen) {
+			searchValue = ''
+		}
+	}
+</script>
+
+<Field {form} {name}>
+	<div class="flex flex-col gap-2">
+		<Control>
+			{#snippet children({ props })}
+				<Label class="text-xs font-medium outline-none">
+					{label}
+				</Label>
+				<Combobox.Root
+					type="single"
+					bind:value={$formData[name]}
+					bind:open
+					onOpenChange={handleOpenChange}
+					{disabled}
+				>
+					<div class="relative">
+						<Combobox.Input
+							{...props}
+							data-testid={computedTestId}
+							oninput={(e) => (searchValue = e.currentTarget.value)}
+							onfocus={() => (open = true)}
+							{placeholder}
+							class="w-full rounded-md border-2 border-transparent bg-slate-100 px-3 py-1.5 pr-8 text-sm text-slate-800 placeholder-slate-500 focus:outline-2 focus:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50 data-fs-error:border-red-300 data-fs-error:bg-red-50 data-fs-error:text-red-600"
+						/>
+						<Combobox.Trigger
+							class="absolute end-2 top-1/2 -translate-y-1/2 text-slate-500"
+							{disabled}
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="h-4 w-4"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+							>
+								<path
+									fill-rule="evenodd"
+									d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+						</Combobox.Trigger>
+					</div>
+
+					<Combobox.Portal>
+						<Combobox.Content
+							class="z-50 mt-1 max-h-60 w-[var(--bits-combobox-anchor-width)] overflow-auto rounded-md border bg-white shadow-lg"
+						>
+							<Combobox.Viewport class="p-1">
+								{#if filteredOptions.length > 0}
+									{#each filteredOptions as option (option.value)}
+										<Combobox.Item
+											value={option.value}
+											label={option.label}
+											class="flex w-full cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm data-highlighted:bg-slate-100"
+										>
+											{#snippet children({ selected })}
+												{#if option.avatar}
+													<img
+														src={option.avatar}
+														alt=""
+														class="h-6 w-6 rounded-full object-cover"
+													/>
+												{:else}
+													<div
+														class="flex h-6 w-6 items-center justify-center rounded-full bg-slate-300 text-xs font-medium text-slate-700"
+													>
+														{option.label.charAt(0).toUpperCase()}
+													</div>
+												{/if}
+												<span class="flex-1">{option.label}</span>
+												{#if selected}
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														class="h-4 w-4 text-sky-600"
+														viewBox="0 0 20 20"
+														fill="currentColor"
+													>
+														<path
+															fill-rule="evenodd"
+															d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L7 12.586l7.293-7.293a1 1 0 011.414 0z"
+															clip-rule="evenodd"
+														/>
+													</svg>
+												{/if}
+											{/snippet}
+										</Combobox.Item>
+									{/each}
+								{:else}
+									<span class="block px-3 py-2 text-sm text-slate-500">No results found</span>
+								{/if}
+							</Combobox.Viewport>
+						</Combobox.Content>
+					</Combobox.Portal>
+				</Combobox.Root>
+			{/snippet}
+		</Control>
+		<Description class="text-xs text-slate-500 data-fs-error:sr-only">{description}</Description>
+		<FieldErrors class="text-xs text-red-600" />
+	</div>
+</Field>

--- a/src/routes/(admin)/admin/content/ContentForm.svelte
+++ b/src/routes/(admin)/admin/content/ContentForm.svelte
@@ -6,6 +6,7 @@
 	import Form from '$lib/ui/form/Form.svelte'
 	import Button from '$lib/ui/Button.svelte'
 	import DynamicSelector from '$lib/ui/form/DynamicSelector.svelte'
+	import AutoComplete from '$lib/ui/form/AutoComplete.svelte'
 	import { getCachedImageWithPreset } from '$lib/utils/image-cache'
 	import { slide } from 'svelte/transition'
 	import CategorySelector from '$lib/ui/form/CategorySelector.svelte'
@@ -62,15 +63,17 @@
 
 	{#if data.users}
 		<div class="grid grid-cols-1 gap-2 space-y-2 rounded-md border-2 border-slate-200 p-4">
-			<Select
+			<AutoComplete
 				name="author_id"
 				label="Author"
+				placeholder="Search for a user..."
 				description={$formData.author_id
 					? 'Change the author or submitter of this content'
 					: 'Select the author or submitter of this content'}
 				options={data.users.map((user) => ({
 					value: user.id,
-					label: `${user.name || user.username} (@${user.username})`
+					label: `${user.name || user.username} (@${user.username})`,
+					avatar: user.avatar_url
 				}))}
 			/>
 			<div>

--- a/tests/e2e/admin/z-content-management.spec.ts
+++ b/tests/e2e/admin/z-content-management.spec.ts
@@ -182,4 +182,46 @@ test.describe('Admin Content Management', () => {
 			}
 		}
 	})
+
+	test('admin can search and filter authors in autocomplete', async ({ page }) => {
+		const dashboardPage = new AdminDashboardPage(page)
+		const editPage = new ContentEditPage(page)
+
+		await dashboardPage.gotoContentManagement()
+		await dashboardPage.expectContentManagementHeading()
+
+		const firstLink = page.getByTestId('content-edit-link').first()
+		await firstLink.waitFor({ state: 'visible' })
+		await firstLink.click()
+		await editPage.expectEditPageLoaded()
+
+		// Verify the author autocomplete is visible
+		await expect(editPage.authorAutocomplete).toBeVisible()
+
+		// Search for a user and verify results appear
+		await editPage.searchAuthor('test')
+		await editPage.expectAuthorResults()
+	})
+
+	test('admin can change content author using autocomplete', async ({ page }) => {
+		const dashboardPage = new AdminDashboardPage(page)
+		const editPage = new ContentEditPage(page)
+
+		await dashboardPage.gotoContentManagement()
+		await dashboardPage.expectContentManagementHeading()
+
+		const firstLink = page.getByTestId('content-edit-link').first()
+		await firstLink.waitFor({ state: 'visible' })
+		await firstLink.click()
+		await editPage.expectEditPageLoaded()
+
+		// Search and select a different author
+		await editPage.searchAuthor('admin')
+		await editPage.expectAuthorResults()
+		await editPage.selectAuthor('admin')
+
+		// Submit the form
+		await editPage.submit()
+		await editPage.expectSuccessMessage()
+	})
 })

--- a/tests/pages/ContentEditPage.ts
+++ b/tests/pages/ContentEditPage.ts
@@ -16,6 +16,7 @@ export class ContentEditPage extends BasePage {
 	readonly statusSelect: Locator
 	readonly submitButton: Locator
 	readonly cancelButton: Locator
+	readonly authorAutocomplete: Locator
 
 	constructor(page: Page) {
 		super(page)
@@ -28,6 +29,7 @@ export class ContentEditPage extends BasePage {
 		this.statusSelect = page.getByTestId('category-selector-status')
 		this.submitButton = page.getByRole('button', { name: 'Update Content' })
 		this.cancelButton = page.getByRole('link', { name: 'Cancel' })
+		this.authorAutocomplete = page.getByTestId('autocomplete-author_id')
 	}
 
 	/**
@@ -186,5 +188,52 @@ export class ContentEditPage extends BasePage {
 		await this.page.waitForURL('/admin/content', { timeout: 10000 })
 		const contentListHeading = this.page.getByRole('heading', { name: 'Content Management' })
 		await expect(contentListHeading).toBeVisible()
+	}
+
+	/**
+	 * Search for an author using the autocomplete
+	 */
+	async searchAuthor(searchText: string): Promise<void> {
+		await this.authorAutocomplete.click()
+		// Wait for the dropdown to open
+		await this.page.waitForSelector('[role="listbox"]', { state: 'visible' })
+		await this.authorAutocomplete.fill(searchText)
+	}
+
+	/**
+	 * Select an author from the autocomplete dropdown
+	 */
+	async selectAuthor(authorLabel: string): Promise<void> {
+		// Click on the matching option in the dropdown (using ARIA role)
+		const option = this.page.locator(`[role="option"]:has-text("${authorLabel}")`).first()
+		await option.click()
+	}
+
+	/**
+	 * Search and select an author in one action
+	 */
+	async changeAuthor(searchText: string, authorLabel: string): Promise<void> {
+		await this.searchAuthor(searchText)
+		await this.selectAuthor(authorLabel)
+	}
+
+	/**
+	 * Expect the author autocomplete dropdown to have results
+	 */
+	async expectAuthorResults(expectedCount?: number): Promise<void> {
+		const items = this.page.locator('[role="option"]')
+		if (expectedCount !== undefined) {
+			await expect(items).toHaveCount(expectedCount)
+		} else {
+			await expect(items.first()).toBeVisible()
+		}
+	}
+
+	/**
+	 * Expect no author results in the dropdown
+	 */
+	async expectNoAuthorResults(): Promise<void> {
+		const noResults = this.page.getByText('No results found')
+		await expect(noResults).toBeVisible()
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces Author Select dropdown with a new form-integrated AutoComplete component
- Provides real-time search/filtering as users type
- Shows user avatars with fallback initials in dropdown items
- Integrates seamlessly with superforms and bits-ui

## Test Plan

- [x] All existing admin content management tests pass (6 tests)
- [x] New E2E tests for author autocomplete search and selection (2 tests)
- [x] Manual testing of autocomplete behavior works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)