### PR TITLE
Disable foreign keys during migrations to prevent data loss

### DIFF
--- a/src/lib/server/db/initiate.ts
+++ b/src/lib/server/db/initiate.ts
@@ -15,10 +15,15 @@ export const initiate_db = async () => {
 	console.log('Initiating database...')
 	const db = new Database(DB_PATH)
 	db.exec('PRAGMA journal_mode = WAL')
-	db.exec('PRAGMA foreign_keys = ON')
+	// Disable foreign keys during migrations to prevent ON DELETE CASCADE
+	// from wiping junction tables when parent tables are dropped/recreated
+	db.exec('PRAGMA foreign_keys = OFF')
 
 	const migrationRunner = new MigrationRunner(db)
 	await migrationRunner.runMigrations()
+
+	// Re-enable foreign keys after migrations complete
+	db.exec('PRAGMA foreign_keys = ON')
 
 	db.close()
 	console.log('Database initialization completed.')


### PR DESCRIPTION
## Summary

- Migration 007 dropped the content table with `PRAGMA foreign_keys = ON` enabled
- SQLite's `ON DELETE CASCADE` on `content_to_users` deleted all author associations
- This fix disables foreign keys during migrations and re-enables them after

## Test plan

- [x] Verify content service tests pass
- [ ] Restore `content_to_users` table from backup taken before migration 007
- [ ] Verify authors display correctly on ContentCards after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)