### PR TITLE
Redesign resource card to 2-column layout

### DIFF
--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -183,7 +183,7 @@
 			>
 		{/if}
 	</h2>
-	{#if content.description && !(fullDescription && content.type === 'recipe')}
+	{#if content.description && !(fullDescription && content.type === 'recipe') && content.type !== 'resource'}
 		<div
 			data-testid="content-description"
 			class={fullDescription
@@ -218,7 +218,7 @@
 				</div>
 			{/if}
 		{:else if content.type === 'resource'}
-			<Resource {content} {priority} />
+			<Resource {content} {priority} {fullDescription} />
 		{/if}
 	</div>
 

--- a/src/lib/ui/content/Resource.svelte
+++ b/src/lib/ui/content/Resource.svelte
@@ -6,9 +6,10 @@
 	interface Props {
 		content: Content
 		priority?: 'high' | 'auto'
+		fullDescription?: boolean
 	}
 
-	let { content, priority = 'auto' }: Props = $props()
+	let { content, priority = 'auto', fullDescription = false }: Props = $props()
 
 	const hasImage = $derived(!!content.metadata?.image)
 	const link = $derived(content.metadata?.link || '#')
@@ -19,35 +20,86 @@
 	const fetchPriorityAttr = $derived(isAboveFold ? 'high' : undefined)
 </script>
 
-<div class="relative flex h-full flex-col gap-2">
-	{#if hasImage}
+{#if fullDescription}
+	<!-- Detail page: full image at top -->
+	<div class="flex flex-col gap-4">
+		{#if content.description}
+			<p data-testid="content-description" class="text-sm sm:text-base">
+				{content.description}
+			</p>
+		{/if}
+
+		{#if hasImage}
+			<a
+				href={link}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-testid="resource-image-link"
+			>
+				<img
+					src={getCachedImageWithPreset(content.metadata.image, 'content', { h: 400 })}
+					width="800"
+					height="400"
+					alt="{content.title} preview"
+					loading={loadingAttr}
+					fetchpriority={fetchPriorityAttr}
+					decoding="async"
+					class="w-full rounded-lg object-cover"
+				/>
+			</a>
+		{/if}
+
 		<a
 			href={link}
 			target="_blank"
 			rel="noopener noreferrer"
-			data-testid="resource-image-link"
+			data-testid="resource-link"
+			class="flex w-fit items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
 		>
-			<img
-				src={getCachedImageWithPreset(content.metadata.image, 'content', { h: 400 })}
-				width="800"
-				height="400"
-				alt="{content.title} preview"
-				loading={loadingAttr}
-				fetchpriority={fetchPriorityAttr}
-				decoding="async"
-				class="w-full rounded-lg object-cover"
-			/>
+			<ArrowSquareOut size={16} />
+			<span class="truncate">{link}</span>
 		</a>
-	{/if}
+	</div>
+{:else}
+	<!-- Card view: 2-column layout with small thumbnail -->
+	<div class="flex items-start gap-4">
+		<div class="flex min-w-0 flex-1 flex-col gap-2">
+			{#if content.description}
+				<p data-testid="content-description" class="line-clamp-2 text-sm sm:text-base">
+					{content.description}
+				</p>
+			{/if}
+			<a
+				href={link}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-testid="resource-link"
+				class="flex w-fit items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
+			>
+				<ArrowSquareOut size={16} />
+				<span class="truncate">{link}</span>
+			</a>
+		</div>
 
-	<a
-		href={link}
-		target="_blank"
-		rel="noopener noreferrer"
-		data-testid="resource-link"
-		class="mt-auto flex items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
-	>
-		<ArrowSquareOut size={16} />
-		<span class="truncate">{link}</span>
-	</a>
-</div>
+		{#if hasImage}
+			<a
+				href={link}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="flex-shrink-0"
+				data-testid="resource-image-link"
+			>
+				<img
+					src={getCachedImageWithPreset(content.metadata.image, 'thumbnail')}
+					width="192"
+					height="108"
+					alt="{content.title} preview"
+					loading={loadingAttr}
+					fetchpriority={fetchPriorityAttr}
+					decoding="async"
+					class="h-[108px] w-48 rounded-lg object-cover"
+				/>
+			</a>
+		{/if}
+	</div>
+{/if}


### PR DESCRIPTION
Redesigns the resource content type card for better space efficiency. The card now uses a 2-column layout with description and link on the left and a smaller thumbnail (192x108) on the right. When viewing the full resource detail page, the image expands to 800x400 with the full description displayed above it.

**Card view:** Description (clamped to 2 lines) + Link button on left, small image on right
**Detail page:** Full description, full-size image (800x400), and link button

All existing tests pass.