### PR TITLE
Fix Resource card overflow on mobile with long URLs

### DIFF
--- a/src/lib/ui/content/Resource.svelte
+++ b/src/lib/ui/content/Resource.svelte
@@ -23,7 +23,7 @@
 
 {#if variant === 'detail'}
 	<!-- Detail page: full image at top -->
-	<div class="flex flex-col gap-4">
+	<div class="flex min-w-0 flex-col gap-4">
 		{#if content.description}
 			<p data-testid="content-description" class="text-sm sm:text-base">
 				{content.description}
@@ -55,16 +55,16 @@
 			target="_blank"
 			rel="noopener noreferrer"
 			data-testid="resource-link"
-			class="flex max-w-full items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
+			class="flex w-full items-center gap-2 overflow-hidden rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
 		>
 			<ArrowSquareOut size={16} class="flex-shrink-0" />
-			<span class="truncate">{link}</span>
+			<span class="w-0 flex-1 truncate">{link}</span>
 		</a>
 	</div>
 {:else}
 	<!-- Card view: 2-column layout with small thumbnail (stacked on mobile) -->
-	<div class="flex flex-col-reverse gap-4 sm:flex-row sm:items-start">
-		<div class="flex min-w-0 flex-1 flex-col gap-2">
+	<div class="flex flex-col-reverse gap-4 overflow-hidden sm:flex-row sm:items-start">
+		<div class="flex w-full min-w-0 flex-1 flex-col gap-2 overflow-hidden">
 			{#if content.description}
 				<p data-testid="content-description" class="line-clamp-2 text-sm sm:text-base">
 					{content.description}
@@ -75,10 +75,10 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				data-testid="resource-link"
-				class="flex max-w-full items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
+				class="flex w-full items-center gap-2 overflow-hidden rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-900"
 			>
 				<ArrowSquareOut size={16} class="flex-shrink-0" />
-				<span class="truncate">{link}</span>
+				<span class="w-0 flex-1 truncate">{link}</span>
 			</a>
 		</div>
 
@@ -87,7 +87,7 @@
 				href={link}
 				target="_blank"
 				rel="noopener noreferrer"
-				class="sm:flex-shrink-0"
+				class="w-full sm:w-auto sm:flex-shrink-0"
 				data-testid="resource-image-link"
 			>
 				<img

--- a/src/lib/ui/contentCard.variants.ts
+++ b/src/lib/ui/contentCard.variants.ts
@@ -1,7 +1,7 @@
 import { tv, type VariantProps } from 'tailwind-variants'
 
 export const contentCardVariants = tv({
-	base: 'grid gap-2 rounded-lg bg-zinc-50',
+	base: 'grid min-w-0 gap-2 rounded-lg bg-zinc-50',
 	variants: {
 		variant: {
 			list: 'px-4 py-4 sm:px-6 sm:py-5',

--- a/src/routes/(app)/(public)/[...type]/+page.svelte
+++ b/src/routes/(app)/(public)/[...type]/+page.svelte
@@ -70,7 +70,7 @@
 <div data-testid="content-list" class="grid gap-6">
 	{#if count > 0}
 		{#each content as content, index (content.id)}
-			<div>
+			<div class="min-w-0">
 				<ContentCard {content} priority={index < 2 ? 'high' : 'auto'} />
 			</div>
 		{/each}


### PR DESCRIPTION
## Summary
- Fixed Resource card URLs expanding beyond card width on mobile
- The `w-0 flex-1 truncate` pattern forces the URL span to start at zero width and grow only to fill available space
- Added `min-w-0` and `overflow-hidden` constraints throughout the container hierarchy

## Test plan
- [ ] View Resource cards on mobile viewport (< 640px)
- [ ] Verify long URLs are properly truncated with ellipsis
- [ ] Verify cards don't expand beyond screen width
- [ ] Check both card list view and detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)