### PR TITLE
Add external link icon to Collection card children

### DIFF
--- a/src/lib/ui/content/Collection.svelte
+++ b/src/lib/ui/content/Collection.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { ContentWithAuthor } from '$lib/types/content'
 	import { formatRelativeDate } from '$lib/utils/date'
+	import ArrowSquareOut from 'phosphor-svelte/lib/ArrowSquareOut'
 
-	// Create a partial Content type for children that doesn't require the children property
 	type ContentChild = Omit<ContentWithAuthor, 'children'> & { children?: any[] }
 
 	interface Props {
@@ -11,30 +11,56 @@
 
 	let { children = [] }: Props = $props()
 
-	// Add default author for content items that don't have one
 	function getAuthor(content: ContentChild): string {
 		return content?.author_name || content?.author_username || 'Unknown'
+	}
+
+	function getExternalUrl(content: ContentChild): string | null {
+		if (content.type === 'resource') {
+			return content.metadata?.link || null
+		}
+		if (content.type === 'library') {
+			return content.metadata?.packageUrl || content.metadata?.github || null
+		}
+		if (content.type === 'video') {
+			return content.metadata?.watchUrl || null
+		}
+		return null
 	}
 </script>
 
 <ul class="space-y-2">
-	{#each children as child}
+	{#each children as child (child.id)}
 		<li
 			class="rounded border border-slate-200 bg-slate-100 px-3 py-1.5 shadow-sm transition-all hover:bg-slate-50 hover:shadow-md"
 		>
-			<a href="/{child.type}/{child.slug}" class="text-svelte-800 hover:text-svelte-600 block">
-				<h2
-					class="text-svelte-800 hover:text-svelte-600 text-md block font-bold break-words"
+			<div class="flex items-center gap-2">
+				<a
+					href="/{child.type}/{child.slug}"
+					class="text-svelte-800 hover:text-svelte-600 block min-w-0 flex-1"
 				>
-					{child?.title || 'Untitled'}
-				</h2>
+					<h2 class="text-svelte-800 hover:text-svelte-600 text-md block font-bold break-words">
+						{child?.title || 'Untitled'}
+					</h2>
 
-				<div class="mb-1 flex text-xs text-gray-500">
-					<span class="mr-0.5 font-semibold capitalize">{child?.type || 'content'}</span>
-					submitted by {getAuthor(child)} •
-					{child?.published_at ? formatRelativeDate(child.published_at) : 'Unknown date'}
-				</div>
-			</a>
+					<div class="mb-1 flex text-xs text-gray-500">
+						<span class="mr-0.5 font-semibold capitalize">{child?.type || 'content'}</span>
+						submitted by {getAuthor(child)} •
+						{child?.published_at ? formatRelativeDate(child.published_at) : 'Unknown date'}
+					</div>
+				</a>
+				{#if getExternalUrl(child)}
+					<a
+						href={getExternalUrl(child)}
+						target="_blank"
+						rel="noopener noreferrer"
+						title="Open external link"
+						class="shrink-0 rounded p-1 text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700"
+					>
+						<ArrowSquareOut size={18} />
+					</a>
+				{/if}
+			</div>
 		</li>
 	{/each}
 </ul>

--- a/src/lib/ui/content/Library.svelte
+++ b/src/lib/ui/content/Library.svelte
@@ -138,7 +138,6 @@
 					target="_blank"
 					rel="noopener noreferrer"
 					class="flex items-center gap-1.5 text-sm text-orange-600 hover:text-orange-700 hover:underline"
-					onclick={(e) => e.stopPropagation()}
 				>
 					<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
 						<path d="M0 0h24v24H0V0z" fill="none"/>


### PR DESCRIPTION
## Summary
Show direct links to external resources for resource, library, and video content types in Collection cards. Each child card now displays an external link icon on the far right that opens the URL in a new tab.

## Changes
- Added `getExternalUrl()` function to determine the external URL based on content type (resource, library, video)
- Added flex layout to child card with external link icon positioned on the right
- Removed unnecessary `stopPropagation()` calls from Collection and Library components

🤖 Generated with [Claude Code](https://claude.com/claude-code)