### PR TITLE
Allow running project without GitHub OAuth configured

### DIFF
--- a/src/routes/(api)/auth/dev-login/+server.ts
+++ b/src/routes/(api)/auth/dev-login/+server.ts
@@ -1,0 +1,59 @@
+import type { RequestHandler } from './$types'
+import { dev } from '$app/environment'
+import { error } from '@sveltejs/kit'
+
+export const GET: RequestHandler = async ({ url, cookies, locals }) => {
+	if (!dev) {
+		throw error(404, 'Not found')
+	}
+
+	const userType = url.searchParams.get('user') || 'admin'
+
+	const testUsers: Record<string, { github_id: number; login: string; name: string }> = {
+		admin: { github_id: 1, login: 'test_admin', name: 'Test Admin' },
+		contributor: { github_id: 2, login: 'test_contributor', name: 'Test Contributor' },
+		viewer: { github_id: 3, login: 'test_viewer', name: 'Test Viewer' }
+	}
+
+	const testUser = testUsers[userType]
+	if (!testUser) {
+		throw error(400, `Invalid user type: ${userType}. Use: admin, contributor, or viewer`)
+	}
+
+	try {
+		const user = locals.userService.createOrUpdateUser({
+			id: testUser.github_id,
+			login: testUser.login,
+			name: testUser.name,
+			email: `${testUser.login}@test.local`,
+			avatar_url: `https://api.dicebear.com/7.x/identicon/svg?seed=${testUser.login}`,
+			bio: null,
+			location: null,
+			twitter_username: null
+		})
+
+		const oldSessionToken = cookies.get('session_id')
+		if (oldSessionToken) {
+			locals.sessionService.deleteSession(oldSessionToken)
+		}
+
+		const sessionToken = locals.sessionService.createSession(user.id)
+
+		cookies.set('session_id', sessionToken, {
+			path: '/',
+			httpOnly: true,
+			secure: false
+		})
+
+		return new Response(null, {
+			status: 303,
+			headers: {
+				Location: '/',
+				'Cache-Control': 'no-store'
+			}
+		})
+	} catch (err) {
+		console.error('Dev login error:', err)
+		throw error(500, 'Failed to create dev session')
+	}
+}

--- a/src/routes/(app)/login/+page.server.ts
+++ b/src/routes/(app)/login/+page.server.ts
@@ -1,11 +1,18 @@
 import type { PageServerLoad } from './$types'
+import { dev } from '$app/environment'
+import { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } from '$env/static/private'
 
 export const load: PageServerLoad = async ({ url }) => {
-	// Hard-coded OAuth providers
-	const authProviders = [{ name: 'GitHub', icon: 'github', color: 'bg-slate-900 text-white' }]
+	const oauthConfigured = Boolean(GITHUB_CLIENT_ID && GITHUB_CLIENT_SECRET)
+
+	const authProviders = oauthConfigured
+		? [{ name: 'GitHub', icon: 'github', color: 'bg-slate-900 text-white' }]
+		: []
 
 	return {
 		authProviders,
+		showDevLogin: dev,
+		oauthConfigured,
 		meta: {
 			title: 'Login - Svelte Society',
 			description: 'Log in to your Svelte Society account',

--- a/src/routes/(app)/login/+page.svelte
+++ b/src/routes/(app)/login/+page.svelte
@@ -46,6 +46,39 @@
 			{/each}
 		</div>
 
+		{#if data.showDevLogin}
+			<div class="mt-8 rounded-lg border-2 border-dashed border-amber-300 bg-amber-50 p-4">
+				<p class="mb-3 text-center text-sm font-medium text-amber-800">
+					Development Mode Login
+				</p>
+				<div class="space-y-2">
+					<a
+						href="/auth/dev-login?user=admin"
+						class="flex w-full items-center justify-center rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-700"
+					>
+						Login as Admin
+					</a>
+					<a
+						href="/auth/dev-login?user=contributor"
+						class="flex w-full items-center justify-center rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600"
+					>
+						Login as Contributor
+					</a>
+					<a
+						href="/auth/dev-login?user=viewer"
+						class="flex w-full items-center justify-center rounded-md bg-amber-400 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-500"
+					>
+						Login as Viewer
+					</a>
+				</div>
+				{#if !data.oauthConfigured}
+					<p class="mt-3 text-center text-xs text-amber-700">
+						GitHub OAuth not configured. Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET to enable.
+					</p>
+				{/if}
+			</div>
+		{/if}
+
 		<div class="mt-6 text-center text-sm">
 			<p class="text-slate-600">
 				By signing in, you agree to our


### PR DESCRIPTION
Add dev-only login endpoint for local development when OAuth credentials are not configured. Users can copy .env.example to .env and use quick login buttons for testing different user roles (admin, contributor, viewer). 

GitHub OAuth only shows when both GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are set as non-empty values in the environment.