### PR TITLE
Add pending_review status dropdown and Orama-based admin content listing

### DIFF
--- a/src/lib/ui/admin/StatusSelect.svelte
+++ b/src/lib/ui/admin/StatusSelect.svelte
@@ -10,6 +10,7 @@
 
 	const statuses = [
 		{ value: 'all', label: 'All Statuses', color: 'default' },
+		{ value: 'pending_review', label: 'Pending Review', color: 'warning' },
 		{ value: 'draft', label: 'Draft', color: 'warning' },
 		{ value: 'published', label: 'Published', color: 'success' },
 		{ value: 'archived', label: 'Archived', color: 'danger' }

--- a/src/routes/(admin)/admin/content/+page.svelte
+++ b/src/routes/(admin)/admin/content/+page.svelte
@@ -79,12 +79,13 @@
 				| 'recipe'
 				| 'resource'
 				| undefined,
-			status: (selectedStatus || 'all') as 'draft' | 'published' | 'archived' | 'all',
+			status: (selectedStatus || 'all') as 'draft' | 'pending_review' | 'published' | 'archived' | 'all',
 			page: currentPage
 		})
 	)
 
 	let colorMap = new Map([
+		['pending_review', 'warning'],
 		['draft', 'warning'],
 		['published', 'success'],
 		['archived', 'danger']
@@ -148,9 +149,6 @@
 				<td class="whitespace-nowrap {classes} font-medium text-gray-900">
 					<a href={`/admin/content/${item.id}`} data-testid="content-edit-link">
 						<div data-testid="content-title-text">{item.title.length > 50 ? item.title.slice(0, 50) + '...' : item.title}</div>
-						<div class="mt-1 text-xs text-gray-400">
-							{item.slug.length > 50 ? item.slug.slice(0, 50) + '...' : item.slug}
-						</div>
 					</a>
 				</td>
 				<td class={classes}


### PR DESCRIPTION
## Summary
- Adds pending_review status option to admin content list dropdown
- Migrates admin content listing to use Orama search directly with custom sorting (pending_review items first, then by creation date)
- Removes slug display from content table as it's not available from Orama

## Test plan
- [x] Verify pending_review option appears in status dropdown
- [x] Verify filtering by pending_review shows only pending items
- [x] Verify all statuses view shows pending_review items first

🤖 Generated with [Claude Code](https://claude.com/claude-code)