### PR TITLE
Fix code block overflow on mobile

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -43,7 +43,6 @@
     }
 
     .prose pre code>.line {
-        display: inline-block;
         width: 100%;
     }
 

--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -191,7 +191,7 @@
 		</div>
 	{/if}
 
-	<div class="mt-2">
+	<div class="mt-2 min-w-0">
 		{#if content.type === 'recipe'}
 			<Recipe {content} {variant} />
 		{:else if content.type === 'collection'}

--- a/src/lib/ui/content/Recipe.svelte
+++ b/src/lib/ui/content/Recipe.svelte
@@ -11,7 +11,7 @@
 </script>
 
 {#if variant === 'detail' && content.rendered_body}
-	<div class="prose prose-sm max-w-none text-gray-700">
+	<div class="prose prose-sm min-w-0 max-w-none text-gray-700">
 		{@html content.rendered_body}
 	</div>
 {/if}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -57,12 +57,12 @@
 	>
 		<LeftSidebar {links} />
 
-		<div class="flex flex-col px-4 pt-8">
+		<div class="flex min-w-0 flex-col px-4 pt-8">
 			<div class="mb-6 shrink-0 sm:hidden">
 				<MobileMenu {links} upcomingEvents={await getUpcomingEvents()} />
 			</div>
 
-			<div class="flex-1 pb-8">
+			<div class="min-w-0 flex-1 pb-8">
 				{@render children()}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
Fix code blocks expanding beyond viewport width on mobile by adding `min-w-0` constraints throughout the layout chain. This allows flex/grid items to shrink below their content size, enabling horizontal scroll on code blocks.

## Changes
- Add `min-w-0` to layout grid item and flex container
- Add `min-w-0` to content wrapper and prose container  
- Remove `display: inline-block` from code lines to respect overflow constraints

## Testing
Code blocks on recipe detail pages should now be scrollable on mobile instead of pushing layout off-screen.