### PR TITLE
Increase code block font size for better readability

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -32,7 +32,7 @@
 /* Syntax highlighting - shiki code blocks */
 @layer components {
     .prose pre {
-        @apply overflow-x-auto rounded-lg py-4 pr-4 pl-2 text-sm;
+        @apply overflow-x-auto rounded-lg py-4 pr-4 pl-2 text-base;
     }
 
     .prose pre code {


### PR DESCRIPTION
Increased code block font size from text-sm (14px) to text-base (16px) for improved readability of syntax-highlighted code blocks throughout the site.