### PR TITLE
Refactor Select to native customizable select with LinkSelect

### DIFF
--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -77,11 +77,11 @@
 	}
 
 	option {
+		position: relative;
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		height: 2rem;
-		padding: 0.75rem 0.375rem 0.75rem 0.75rem;
+		padding: 0.75rem 2rem 0.75rem 0.75rem;
 		font-size: 0.875rem;
 		border-radius: 0.125rem;
 		text-transform: capitalize;
@@ -93,6 +93,7 @@
 	}
 
 	option::checkmark {
-		margin-left: auto;
+		position: absolute;
+		right: 0.5rem;
 	}
 </style>

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -96,4 +96,11 @@
 		position: absolute;
 		right: 0.5rem;
 	}
+
+	/* CaretUpDown icon from phosphor-svelte */
+	select::picker-icon {
+		content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='%236b7280'%3E%3Cpath d='M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48a8,8,0,0,0,11.32,11.32Z'/%3E%3C/svg%3E");
+		width: 1rem;
+		height: 1rem;
+	}
 </style>

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -79,6 +79,7 @@
 	option {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		height: 2rem;
 		padding: 0.75rem 0.375rem 0.75rem 0.75rem;
 		font-size: 0.875rem;

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -73,7 +73,7 @@
 		background: white;
 		padding: 0.75rem 0.25rem;
 		box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
-		min-width: 100%;
+		width: anchor-size(width);
 	}
 
 	option {

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -39,22 +39,24 @@
 </select>
 
 <style>
-	select,
-	::picker(select) {
-		appearance: base-select;
-	}
-
+	/* Base styles for all browsers (Safari fallback) */
 	select {
 		width: 100%;
 		min-width: 9rem;
-		padding: 0.25rem 0.75rem 0.25rem 0.5rem;
+		padding: 0.5rem 2rem 0.5rem 0.5rem;
 		background: rgb(241 245 249); /* slate-100 */
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='%236b7280'%3E%3Cpath d='M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48a8,8,0,0,0,11.32,11.32Z'/%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-position: right 0.5rem center;
+		background-size: 1rem;
 		border: 2px solid transparent;
 		border-radius: 0.375rem;
 		font-size: 0.875rem;
 		line-height: 1.25rem;
 		text-align: left;
 		cursor: pointer;
+		appearance: none;
+		-webkit-appearance: none;
 	}
 
 	select:focus {
@@ -63,44 +65,57 @@
 
 	select:disabled {
 		cursor: not-allowed;
-		background: rgb(243 244 246); /* gray-100 */
+		background-color: rgb(243 244 246); /* gray-100 */
 		color: rgb(107 114 128); /* gray-500 */
 	}
 
-	::picker(select) {
-		border: none;
-		border-radius: 0.75rem;
-		background: white;
-		padding: 0.75rem 0.25rem;
-		box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
-		width: anchor-size(width);
-	}
+	/* Enhanced styles for browsers supporting base-select */
+	@supports (appearance: base-select) {
+		select,
+		::picker(select) {
+			appearance: base-select;
+		}
 
-	option {
-		position: relative;
-		display: flex;
-		align-items: center;
-		height: 2rem;
-		padding: 0.75rem 2rem 0.75rem 0.75rem;
-		font-size: 0.875rem;
-		border-radius: 0.125rem;
-		text-transform: capitalize;
-	}
+		select {
+			padding: 0.25rem 0.75rem 0.25rem 0.5rem;
+			background-image: none;
+		}
 
-	option:hover,
-	option:focus {
-		background: rgb(243 244 246); /* gray-100 */
-	}
+		::picker(select) {
+			border: none;
+			border-radius: 0.75rem;
+			background: white;
+			padding: 0.75rem 0.25rem;
+			box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+			width: anchor-size(width);
+		}
 
-	option::checkmark {
-		position: absolute;
-		right: 0.5rem;
-	}
+		option {
+			position: relative;
+			display: flex;
+			align-items: center;
+			height: 2rem;
+			padding: 0.75rem 2rem 0.75rem 0.75rem;
+			font-size: 0.875rem;
+			border-radius: 0.125rem;
+			text-transform: capitalize;
+		}
 
-	/* CaretUpDown icon from phosphor-svelte */
-	select::picker-icon {
-		content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='%236b7280'%3E%3Cpath d='M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48a8,8,0,0,0,11.32,11.32Z'/%3E%3C/svg%3E");
-		width: 1rem;
-		height: 1rem;
+		option:hover,
+		option:focus {
+			background: rgb(243 244 246); /* gray-100 */
+		}
+
+		option::checkmark {
+			position: absolute;
+			right: 0.5rem;
+		}
+
+		/* CaretUpDown icon from phosphor-svelte */
+		select::picker-icon {
+			content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='%236b7280'%3E%3Cpath d='M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48a8,8,0,0,0,11.32,11.32Z'/%3E%3C/svg%3E");
+			width: 1rem;
+			height: 1rem;
+		}
 	}
 </style>

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -43,7 +43,7 @@
 	select {
 		width: 100%;
 		min-width: 9rem;
-		padding: 0.5rem 2rem 0.5rem 0.5rem;
+		padding: 0.25rem 2rem 0.25rem 0.5rem;
 		background: rgb(241 245 249); /* slate-100 */
 		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='%236b7280'%3E%3Cpath d='M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48a8,8,0,0,0,11.32,11.32Z'/%3E%3C/svg%3E");
 		background-repeat: no-repeat;

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import CaretUpDown from 'phosphor-svelte/lib/CaretUpDown'
-	import Check from 'phosphor-svelte/lib/Check'
-	import { Select } from 'bits-ui'
+	import type { HTMLSelectAttributes } from 'svelte/elements'
+
 	type Option = {
 		label: string
 		value: string
@@ -10,58 +9,89 @@
 	type Props = {
 		options: Option[]
 		value?: string
-		name: string
-		selected?: string
-		props?: any
-		disabled?: boolean
 		onchange?: (value: string) => void
-		testId?: string
-	}
+		'data-testid'?: string
+	} & HTMLSelectAttributes
+
 	let {
 		options,
 		value = $bindable(),
-		name,
-		props,
-		disabled = false,
 		onchange,
-		testId
+		'data-testid': testId,
+		...rest
 	}: Props = $props()
 
-	const placeholder = $derived(props?.placeholder || 'Select...')
-	const selectedLabel = $derived(options.find((option) => option.value === value)?.label)
+	function handleChange(e: Event) {
+		const target = e.target as HTMLSelectElement
+		value = target.value
+		onchange?.(target.value)
+	}
+
+	const computedTestId = $derived(testId)
 </script>
 
-<Select.Root type="single" bind:value onValueChange={onchange} {name} {disabled}>
-	<Select.Trigger
-		{...props}
-		class="focus:outline-svelte-300 grid w-full grid-cols-[1fr_auto] items-center rounded-md border-2 border-transparent bg-slate-100 px-3 py-1 pl-2 text-left text-sm placeholder-slate-500 focus:outline-2 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 data-fs-error:border-red-300 data-fs-error:bg-red-50 data-fs-error:text-red-600"
-		{disabled}
-		tabindex={disabled ? -1 : 0}
-		aria-label={selectedLabel || 'Select an option'}
-		data-testid={testId}
-	>
-		{selectedLabel || placeholder}
-		<CaretUpDown class="ml-auto size-4 text-gray-500" />
-	</Select.Trigger>
-	<Select.Portal>
-		<Select.Content
-			class="focus-override z-50 w-(--bits-select-anchor-width) min-w-(--bits-select-anchor-width) rounded-xl bg-white px-1 py-3 shadow-2xl outline-hidden select-none data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
-		>
-			{#each options as option}
-				<Select.Item
-					value={option.value}
-					class="flex h-8 w-full items-center rounded-sm py-3 pr-1.5 pl-3 text-sm capitalize outline-hidden select-none data-disabled:opacity-50 data-highlighted:bg-gray-100"
-				>
-					{#snippet children({ selected })}
-						{option.label}
-						{#if selected}
-							<div class="ml-auto">
-								<Check />
-							</div>
-						{/if}
-					{/snippet}
-				</Select.Item>
-			{/each}
-		</Select.Content>
-	</Select.Portal>
-</Select.Root>
+<select bind:value onchange={handleChange} data-testid={computedTestId} {...rest}>
+	{#each options as option}
+		<option value={option.value}>
+			{option.label}
+		</option>
+	{/each}
+</select>
+
+<style>
+	select,
+	::picker(select) {
+		appearance: base-select;
+	}
+
+	select {
+		width: 100%;
+		min-width: 9rem;
+		padding: 0.25rem 0.75rem 0.25rem 0.5rem;
+		background: rgb(241 245 249); /* slate-100 */
+		border: 2px solid transparent;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		line-height: 1.25rem;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	select:focus {
+		outline: 2px solid rgb(253 186 116); /* svelte-300 */
+	}
+
+	select:disabled {
+		cursor: not-allowed;
+		background: rgb(243 244 246); /* gray-100 */
+		color: rgb(107 114 128); /* gray-500 */
+	}
+
+	::picker(select) {
+		border: none;
+		border-radius: 0.75rem;
+		background: white;
+		padding: 0.75rem 0.25rem;
+		box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+		min-width: 100%;
+	}
+
+	option {
+		display: flex;
+		align-items: center;
+		height: 2rem;
+		padding: 0.75rem 0.375rem 0.75rem 0.75rem;
+		font-size: 0.875rem;
+		border-radius: 0.125rem;
+		text-transform: capitalize;
+	}
+
+	option:hover,
+	option:focus {
+		background: rgb(243 244 246); /* gray-100 */
+	}
+
+	option::checkmark {
+		margin-left: auto;
+	}
+</style>

--- a/src/lib/ui/admin/StatusSelect.svelte
+++ b/src/lib/ui/admin/StatusSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Badge from './Badge.svelte'
+	import Select from '$lib/ui/Select.svelte'
 
 	type Props = {
 		value: string
@@ -8,39 +8,13 @@
 
 	let { value = 'all', onchange }: Props = $props()
 
-	const statuses = [
-		{ value: 'all', label: 'All Statuses', color: 'default' },
-		{ value: 'pending_review', label: 'Pending Review', color: 'warning' },
-		{ value: 'draft', label: 'Draft', color: 'warning' },
-		{ value: 'published', label: 'Published', color: 'success' },
-		{ value: 'archived', label: 'Archived', color: 'danger' }
-	] as const
-
-	function handleChange(e: Event) {
-		const target = e.target as HTMLSelectElement
-		onchange(target.value)
-	}
-
-	const currentStatus = $derived(statuses.find((s) => s.value === value) || statuses[0])
+	const options = [
+		{ value: 'all', label: 'All Statuses' },
+		{ value: 'pending_review', label: 'Pending Review' },
+		{ value: 'draft', label: 'Draft' },
+		{ value: 'published', label: 'Published' },
+		{ value: 'archived', label: 'Archived' }
+	]
 </script>
 
-<div class="relative">
-	<select
-		{value}
-		onchange={handleChange}
-		class="block w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-10 pl-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
-	>
-		{#each statuses as status}
-			<option value={status.value}>{status.label}</option>
-		{/each}
-	</select>
-	<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-		<svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	</div>
-</div>
+<Select name="status" {value} {options} {onchange} />

--- a/src/lib/ui/admin/TypeSelect.svelte
+++ b/src/lib/ui/admin/TypeSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import TypeIcon from '$lib/ui/TypeIcon.svelte'
+	import Select from '$lib/ui/Select.svelte'
 
 	type Props = {
 		value: string
@@ -8,7 +8,7 @@
 
 	let { value = '', onchange }: Props = $props()
 
-	const types = [
+	const options = [
 		{ value: '', label: 'All Types' },
 		{ value: 'video', label: 'Video' },
 		{ value: 'library', label: 'Library' },
@@ -16,31 +16,7 @@
 		{ value: 'announcement', label: 'Announcement' },
 		{ value: 'collection', label: 'Collection' },
 		{ value: 'recipe', label: 'Recipe' }
-	] as const
-
-	function handleChange(e: Event) {
-		const target = e.target as HTMLSelectElement
-		onchange(target.value)
-	}
+	]
 </script>
 
-<div class="relative">
-	<select
-		{value}
-		onchange={handleChange}
-		class="block w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-10 pl-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
-	>
-		{#each types as type}
-			<option value={type.value}>{type.label}</option>
-		{/each}
-	</select>
-	<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-		<svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	</div>
-</div>
+<Select name="type" {value} {options} {onchange} />

--- a/src/lib/ui/filter/FilterDropdown.svelte
+++ b/src/lib/ui/filter/FilterDropdown.svelte
@@ -121,7 +121,7 @@
 		role="menu"
 		aria-label="Filter options"
 		bind:this={menuEl}
-		class="invisible absolute left-0 top-full z-50 mt-1 min-w-44 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100"
+		class="invisible absolute left-0 right-0 top-full z-50 mt-1 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100"
 	>
 		<FilterSubmenu label="Categories" paramName="type" getItems={getCategories} onSelect={handleSelect} />
 		<FilterSubmenu label="Tags" paramName="tags" getItems={getTags} onSelect={handleSelect} />

--- a/src/lib/ui/filter/FilterSubmenu.svelte
+++ b/src/lib/ui/filter/FilterSubmenu.svelte
@@ -88,10 +88,10 @@
 		aria-haspopup="true"
 		aria-expanded={isOpen}
 		bind:this={triggerEl}
-		class="group/button flex h-8 w-full cursor-pointer items-center justify-between rounded-sm py-3 pr-1.5 pl-3 text-left text-sm outline-hidden hover:bg-svelte-50 focus:bg-svelte-100 group-focus-within/submenu:bg-svelte-50"
+		class="group/button flex h-8 w-full cursor-pointer items-center justify-between rounded-sm py-3 pr-1.5 pl-3 text-left text-sm outline-hidden hover:bg-gray-100 focus:bg-gray-100 group-focus-within/submenu:bg-gray-100"
 	>
 		<span>{label}</span>
-		<CaretRight class="size-4 text-gray-400 group-hover/button:text-svelte-900 group-focus/button:text-svelte-900 group-focus-within/submenu:text-svelte-900" />
+		<CaretRight class="size-4 text-gray-400 group-hover/button:text-gray-900 group-focus/button:text-gray-900 group-focus-within/submenu:text-gray-900" />
 		<span class="sr-only">Open submenu</span>
 	</div>
 	<div
@@ -113,7 +113,7 @@
 						e.currentTarget.click()
 					}
 				}}
-				class="flex h-8 w-full items-center justify-between rounded-sm py-3 pr-2 pl-3 text-sm outline-hidden hover:bg-svelte-50 focus:bg-svelte-100"
+				class="flex h-8 w-full items-center justify-between rounded-sm py-3 pr-2 pl-3 text-sm outline-hidden hover:bg-gray-100 focus:bg-gray-100"
 			>
 				{item.label}
 				{#if isActive}

--- a/src/lib/ui/filter/LinkSelect.svelte
+++ b/src/lib/ui/filter/LinkSelect.svelte
@@ -172,7 +172,7 @@
 		role="listbox"
 		aria-label="{paramName} options"
 		bind:this={menuEl}
-		class="invisible absolute left-0 top-full z-50 mt-1 min-w-44 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100"
+		class="invisible absolute left-0 right-0 top-full z-50 mt-1 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100"
 	>
 		{#each options as option (option.value)}
 			{@const isActive = currentValue === option.value}

--- a/src/lib/ui/filter/LinkSelect.svelte
+++ b/src/lib/ui/filter/LinkSelect.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	import CaretUpDown from 'phosphor-svelte/lib/CaretUpDown'
+	import Check from 'phosphor-svelte/lib/Check'
+	import { page } from '$app/state'
+	import { afterNavigate } from '$app/navigation'
+	import { getCategoryFromRoute } from './url-helpers'
+
+	type Option = {
+		label: string
+		value: string
+	}
+
+	type Props = {
+		options: Option[]
+		paramName: string
+		defaultValue?: string
+	}
+
+	let { options, paramName, defaultValue = '' }: Props = $props()
+
+	let isOpen = $state(false)
+	let shouldFocusTrigger = $state(false)
+
+	afterNavigate(() => {
+		if (shouldFocusTrigger) {
+			triggerEl?.focus()
+			shouldFocusTrigger = false
+		}
+	})
+
+	function handleSelect() {
+		shouldFocusTrigger = true
+	}
+
+	let wasFocusedBeforeClick = false
+
+	function handleTriggerMousedown() {
+		wasFocusedBeforeClick = document.activeElement === triggerEl
+	}
+
+	function handleTriggerClick() {
+		if (wasFocusedBeforeClick) {
+			triggerEl?.blur()
+		}
+	}
+
+	function handleTriggerKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault()
+			if (isOpen) {
+				triggerEl?.blur()
+			}
+		}
+	}
+
+	let containerEl: HTMLDivElement | undefined = $state()
+	let triggerEl: HTMLDivElement | undefined = $state()
+	let menuEl: HTMLDivElement | undefined = $state()
+
+	function handleFocusIn() {
+		isOpen = true
+	}
+
+	function handleFocusOut(e: FocusEvent) {
+		if (containerEl && !containerEl.contains(e.relatedTarget as Node)) {
+			isOpen = false
+		}
+	}
+
+	function getMenuItems(): HTMLElement[] {
+		if (!menuEl) return []
+		return Array.from(menuEl.querySelectorAll<HTMLElement>('a'))
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault()
+			isOpen = false
+			if (document.activeElement instanceof HTMLElement) {
+				document.activeElement.blur()
+			}
+			return
+		}
+
+		const items = getMenuItems()
+		if (items.length === 0) return
+
+		const currentIndex = items.findIndex((item) => item === document.activeElement)
+
+		if (e.key === 'ArrowDown') {
+			e.preventDefault()
+			if (document.activeElement === triggerEl) {
+				items[0]?.focus()
+			} else if (currentIndex >= 0 && currentIndex < items.length - 1) {
+				items[currentIndex + 1]?.focus()
+			}
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault()
+			if (currentIndex > 0) {
+				items[currentIndex - 1]?.focus()
+			} else if (currentIndex === 0) {
+				triggerEl?.focus()
+			}
+		}
+	}
+
+	// Get current value from URL or use default
+	let currentValue = $derived(page.url.searchParams.get(paramName) ?? defaultValue)
+
+	// Find the label for the current value
+	let currentLabel = $derived(
+		options.find((opt) => opt.value === currentValue)?.label ?? options[0]?.label ?? ''
+	)
+
+	// Build href that sets the param value (not toggle)
+	function buildSetHref(value: string): string {
+		const categoryType = getCategoryFromRoute(page.route.id, page.params)
+
+		// If on category page, redirect to homepage
+		const newUrl = categoryType ? new URL('/', page.url.origin) : new URL(page.url)
+
+		// If redirecting from category page, copy existing params and add type
+		if (categoryType) {
+			newUrl.searchParams.append('type', categoryType)
+			page.url.searchParams.forEach((v, k) => {
+				if (k !== 'page' && k !== paramName) {
+					newUrl.searchParams.append(k, v)
+				}
+			})
+		}
+
+		// Set the value (replace existing)
+		newUrl.searchParams.delete(paramName)
+		if (value !== defaultValue && value !== '') {
+			newUrl.searchParams.set(paramName, value)
+		}
+
+		// Reset pagination
+		newUrl.searchParams.delete('page')
+
+		return newUrl.pathname + newUrl.search
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+	role="group"
+	class="group/dropdown relative inline-block"
+	bind:this={containerEl}
+	onfocusin={handleFocusIn}
+	onfocusout={handleFocusOut}
+	onkeydown={handleKeydown}
+>
+	<div
+		role="button"
+		tabindex="0"
+		aria-haspopup="listbox"
+		aria-expanded={isOpen}
+		aria-label="Select {paramName}"
+		bind:this={triggerEl}
+		onmousedown={handleTriggerMousedown}
+		ontouchstart={handleTriggerMousedown}
+		onclick={handleTriggerClick}
+		onkeydown={handleTriggerKeydown}
+		class="grid w-full min-w-36 cursor-pointer grid-cols-[1fr_auto] items-center rounded-md border-2 border-transparent bg-slate-100 px-3 py-1 pl-2 text-left text-sm focus:outline-2 focus:outline-svelte-300"
+	>
+		{currentLabel}
+		<CaretUpDown class="ml-auto size-4 text-gray-500" />
+	</div>
+
+	<div
+		role="listbox"
+		aria-label="{paramName} options"
+		bind:this={menuEl}
+		class="invisible absolute left-0 top-full z-50 mt-1 min-w-44 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100"
+	>
+		{#each options as option (option.value)}
+			{@const isActive = currentValue === option.value}
+			<a
+				href={buildSetHref(option.value)}
+				role="option"
+				aria-selected={isActive}
+				onclick={() => handleSelect()}
+				onkeydown={(e) => {
+					if (e.key === ' ') {
+						e.preventDefault()
+						e.currentTarget.click()
+					}
+				}}
+				class="flex h-8 w-full items-center justify-between rounded-sm py-3 pr-2 pl-3 text-sm outline-hidden hover:bg-gray-100 focus:bg-gray-100"
+			>
+				{option.label}
+				{#if isActive}
+					<Check class="size-4 text-svelte-500" weight="bold" />
+				{/if}
+			</a>
+		{/each}
+	</div>
+</div>

--- a/src/routes/(admin)/admin/announcements/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/announcements/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state'
 	import Input from '$lib/ui/Input.svelte'
 	import Button from '$lib/ui/Button.svelte'
+	import Select from '$lib/ui/Select.svelte'
 	import PageHeader from '$lib/ui/admin/PageHeader.svelte'
 	import Megaphone from 'phosphor-svelte/lib/Megaphone'
 	import { initForm } from '$lib/utils/form.svelte'
@@ -51,23 +52,11 @@
 				<div class="grid gap-6 lg:grid-cols-2">
 					<div class="flex flex-col gap-2">
 						<label for="content_id" class="text-xs font-medium">Announcement</label>
-						<select
+						<Select
 							{...updatePlacement.fields.content_id.as('select')}
-							id="content_id"
-							class={[
-								'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-								'focus:outline-2 focus:outline-sky-200',
-								(updatePlacement.fields.content_id.issues() ?? []).length > 0
-									? 'border-red-300 bg-red-50 text-red-600'
-									: 'border-transparent'
-							]}
+							options={[{ value: '', label: 'Select an announcement' }, ...announcementOptions]}
 							data-testid="select-content_id"
-						>
-							<option value="">Select an announcement</option>
-							{#each announcementOptions as option (option.value)}
-								<option value={option.value}>{option.label}</option>
-							{/each}
-						</select>
+						/>
 						{#each updatePlacement.fields.content_id.issues() ?? [] as issue, i (i)}
 							<p class="text-xs text-red-600">{issue.message}</p>
 						{:else}
@@ -77,23 +66,11 @@
 
 					<div class="flex flex-col gap-2">
 						<label for="placement_location_id" class="text-xs font-medium">Placement Location</label>
-						<select
+						<Select
 							{...updatePlacement.fields.placement_location_id.as('select')}
-							id="placement_location_id"
-							class={[
-								'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-								'focus:outline-2 focus:outline-sky-200',
-								(updatePlacement.fields.placement_location_id.issues() ?? []).length > 0
-									? 'border-red-300 bg-red-50 text-red-600'
-									: 'border-transparent'
-							]}
+							options={[{ value: '', label: 'Select a location' }, ...locationOptions]}
 							data-testid="select-placement_location_id"
-						>
-							<option value="">Select a location</option>
-							{#each locationOptions as option (option.value)}
-								<option value={option.value}>{option.label}</option>
-							{/each}
-						</select>
+						/>
 						{#each updatePlacement.fields.placement_location_id.issues() ?? [] as issue, i (i)}
 							<p class="text-xs text-red-600">{issue.message}</p>
 						{:else}

--- a/src/routes/(admin)/admin/announcements/new/+page.svelte
+++ b/src/routes/(admin)/admin/announcements/new/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Input from '$lib/ui/Input.svelte'
 	import Button from '$lib/ui/Button.svelte'
+	import Select from '$lib/ui/Select.svelte'
 	import PageHeader from '$lib/ui/admin/PageHeader.svelte'
 	import Megaphone from 'phosphor-svelte/lib/Megaphone'
 	import { createPlacement, getAnnouncements, getLocations } from '../announcements.remote'
@@ -29,23 +30,11 @@
 				<div class="grid gap-6 lg:grid-cols-2">
 					<div class="flex flex-col gap-2">
 						<label for="content_id" class="text-xs font-medium">Announcement</label>
-						<select
+						<Select
 							{...createPlacement.fields.content_id.as('select')}
-							id="content_id"
-							class={[
-								'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-								'focus:outline-2 focus:outline-sky-200',
-								(createPlacement.fields.content_id.issues() ?? []).length > 0
-									? 'border-red-300 bg-red-50 text-red-600'
-									: 'border-transparent'
-							]}
+							options={[{ value: '', label: 'Select an announcement' }, ...announcementOptions]}
 							data-testid="select-content_id"
-						>
-							<option value="">Select an announcement</option>
-							{#each announcementOptions as option (option.value)}
-								<option value={option.value}>{option.label}</option>
-							{/each}
-						</select>
+						/>
 						{#each createPlacement.fields.content_id.issues() ?? [] as issue, i (i)}
 							<p class="text-xs text-red-600">{issue.message}</p>
 						{:else}
@@ -55,23 +44,11 @@
 
 					<div class="flex flex-col gap-2">
 						<label for="placement_location_id" class="text-xs font-medium">Placement Location</label>
-						<select
+						<Select
 							{...createPlacement.fields.placement_location_id.as('select')}
-							id="placement_location_id"
-							class={[
-								'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-								'focus:outline-2 focus:outline-sky-200',
-								(createPlacement.fields.placement_location_id.issues() ?? []).length > 0
-									? 'border-red-300 bg-red-50 text-red-600'
-									: 'border-transparent'
-							]}
+							options={[{ value: '', label: 'Select a location' }, ...locationOptions]}
 							data-testid="select-placement_location_id"
-						>
-							<option value="">Select a location</option>
-							{#each locationOptions as option (option.value)}
-								<option value={option.value}>{option.label}</option>
-							{/each}
-						</select>
+						/>
 						{#each createPlacement.fields.placement_location_id.issues() ?? [] as issue, i (i)}
 							<p class="text-xs text-red-600">{issue.message}</p>
 						{:else}

--- a/src/routes/(admin)/admin/content/ContentForm.svelte
+++ b/src/routes/(admin)/admin/content/ContentForm.svelte
@@ -5,6 +5,7 @@
 	import TextArea from '$lib/ui/TextArea.svelte'
 	import MarkdownEditor from '$lib/ui/MarkdownEditor.svelte'
 	import DynamicSelector from '$lib/ui/DynamicSelector.svelte'
+	import Select from '$lib/ui/Select.svelte'
 	import { getCachedImageWithPreset } from '$lib/utils/image-cache'
 	import { refreshMetadata } from './data.remote'
 	import type { RemoteForm } from '@sveltejs/kit'
@@ -178,22 +179,11 @@
 			{#if !isEditing}
 				<div class="flex flex-col gap-2">
 					<label for="type" class="text-xs font-medium">Content Type</label>
-					<select
+					<Select
 						{...form.fields.type.as('select')}
-						id="type"
-						class={[
-							'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-							'focus:outline-2 focus:outline-sky-200',
-							(form.fields.type.issues() ?? []).length > 0
-								? 'border-red-300 bg-red-50 text-red-600'
-								: 'border-transparent'
-						]}
+						options={typeOptions}
 						data-testid="select-type"
-					>
-						{#each typeOptions as option (option.value)}
-							<option value={option.value}>{option.label}</option>
-						{/each}
-					</select>
+					/>
 					<p class="text-xs text-slate-500">Select the type of content</p>
 					{#each form.fields.type.issues() ?? [] as issue, i (i)}
 						<p class="text-xs text-red-600">{issue.message}</p>
@@ -203,23 +193,16 @@
 
 			<div class="flex flex-col gap-2">
 				<label for="status" class="text-xs font-medium">Status</label>
-				<select
+				<Select
 					{...form.fields.status.as('select')}
-					id="status"
-					class={[
-						'w-full rounded-md border-2 bg-slate-100 px-3 py-1.5 text-sm',
-						'focus:outline-2 focus:outline-sky-200',
-						(form.fields.status.issues() ?? []).length > 0
-							? 'border-red-300 bg-red-50 text-red-600'
-							: 'border-transparent'
+					options={[
+						{ value: 'draft', label: 'Draft' },
+						{ value: 'pending_review', label: 'Pending Review' },
+						{ value: 'published', label: 'Published' },
+						{ value: 'archived', label: 'Archived' }
 					]}
 					data-testid="select-status"
-				>
-					<option value="draft">Draft</option>
-					<option value="pending_review">Pending Review</option>
-					<option value="published">Published</option>
-					<option value="archived">Archived</option>
-				</select>
+				/>
 				<p class="text-xs text-slate-500">Select the publication status</p>
 				{#each form.fields.status.issues() ?? [] as issue, i (i)}
 					<p class="text-xs text-red-600">{issue.message}</p>
@@ -232,17 +215,11 @@
 		<div class="grid grid-cols-1 gap-2 space-y-2 rounded-md border-2 border-slate-200 p-4">
 			<div class="flex flex-col gap-2">
 				<label for="author_id" class="text-xs font-medium">Author</label>
-				<select
+				<Select
 					{...form.fields.author_id.as('select')}
-					id="author_id"
-					class="w-full rounded-md border-2 border-transparent bg-slate-100 px-3 py-1.5 text-sm focus:outline-2 focus:outline-sky-200"
+					options={[{ value: '', label: 'Select an author...' }, ...users]}
 					data-testid="select-author"
-				>
-					<option value="">Select an author...</option>
-					{#each users as user (user.value)}
-						<option value={user.value}>{user.label}</option>
-					{/each}
-				</select>
+				/>
 				<p class="text-xs text-slate-500">
 					{authorId
 						? 'Change the author or submitter of this content'

--- a/src/routes/(admin)/admin/users/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/users/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import Input from '$lib/ui/Input.svelte'
 	import Button from '$lib/ui/Button.svelte'
 	import Avatar from '$lib/ui/Avatar.svelte'
+	import Select from '$lib/ui/Select.svelte'
 	import PageHeader from '$lib/ui/admin/PageHeader.svelte'
 	import User from 'phosphor-svelte/lib/User'
 	import { initForm } from '$lib/utils/form.svelte'
@@ -89,20 +90,18 @@
 					</div>
 				</div>
 
+				{#await getRoleOptions() then roleOptions}
 				<div class="mt-4 border-t border-gray-200 pt-6">
 					<form {...roleForm} class="flex items-end gap-4">
 						<div class="flex grow flex-col gap-2">
 							<label class="text-xs font-medium outline-none" for="role">Role</label>
-							<select
-								{...roleForm.fields.role.as('number')}
+							<Select
+								name="role"
+								value={roleForm.fields.role.value()?.toString()}
+								options={roleOptions.map((r) => ({ label: r.label, value: r.value.toString() }))}
+								onchange={(v) => roleForm.fields.role.set(parseInt(v))}
 								data-testid="select-role"
-								class="w-full appearance-none rounded-md border-2 border-transparent bg-slate-100 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%3E%3Cpath%20fill%3D%22%236b7280%22%20d%3D%22M213.66%20101.66l-80%2080a8%208%200%2001-11.32%200l-80-80a8%208%200%200111.32-11.32L128%20164.69l74.34-74.35a8%208%200%200111.32%2011.32z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1rem] bg-[right_0.5rem_center] bg-no-repeat px-2 py-1.5 pr-8 text-sm focus:outline-2 focus:outline-sky-200 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
-							>
-								{#each await getRoleOptions() as { label, value }}
-									<option value={value.toString()}>{label}</option>
-								{/each}
-							</select>
-
+							/>
 							<p class="text-xs text-slate-500">Select the user's role</p>
 						</div>
 						<Button type="submit" disabled={!!roleForm.pending} data-testid="submit-button">
@@ -110,6 +109,7 @@
 						</Button>
 					</form>
 				</div>
+				{/await}
 
 				<div class="mt-4 border-t border-gray-200 pt-6">
 					<Button href="/admin/users" variant="secondary">Back to Users</Button>

--- a/src/routes/(app)/(public)/FilterForm.svelte
+++ b/src/routes/(app)/(public)/FilterForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Button from '$lib/ui/Button.svelte'
 	import FilterDropdown from '$lib/ui/filter/FilterDropdown.svelte'
 	import LinkSelect from '$lib/ui/filter/LinkSelect.svelte'
 	import ActiveFilters from '$lib/ui/filter/ActiveFilters.svelte'
@@ -16,7 +15,7 @@
 	let { sort }: Props = $props()
 </script>
 
-<form class="@container grid gap-4">
+<div class="@container grid gap-4">
 	<div class="grid w-full grid-cols-1 gap-4 @xs:grid-cols-2">
 		<div class="flex w-full flex-col gap-2">
 			<span class="text-xs font-medium">Filter</span>
@@ -28,7 +27,4 @@
 		</div>
 	</div>
 	<ActiveFilters />
-	<div class="sr-only">
-		<Button type="submit">Filter</Button>
-	</div>
-</form>
+</div>

--- a/src/routes/(app)/(public)/FilterForm.svelte
+++ b/src/routes/(app)/(public)/FilterForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import Select from '$lib/ui/Select.svelte'
 	import Button from '$lib/ui/Button.svelte'
 	import FilterDropdown from '$lib/ui/filter/FilterDropdown.svelte'
+	import LinkSelect from '$lib/ui/filter/LinkSelect.svelte'
 	import ActiveFilters from '$lib/ui/filter/ActiveFilters.svelte'
 
 	type Option = {
@@ -11,11 +11,9 @@
 
 	type Props = {
 		sort: Option[]
-		filters: URL
-		updateSort: (value: string) => void
 	}
 
-	let { sort, filters, updateSort }: Props = $props()
+	let { sort }: Props = $props()
 </script>
 
 <form class="@container grid gap-4">
@@ -25,13 +23,8 @@
 			<FilterDropdown />
 		</div>
 		<div class="flex w-full flex-col gap-2">
-			<label for="sort" class="text-xs font-medium outline-none">Sort</label>
-			<Select
-				value={filters.searchParams.get('sort') || sort[0].value}
-				name="sort"
-				onchange={updateSort}
-				options={sort}
-			/>
+			<span class="text-xs font-medium">Sort</span>
+			<LinkSelect options={sort} paramName="sort" defaultValue={sort[0]?.value} />
 		</div>
 	</div>
 	<ActiveFilters />

--- a/src/routes/(app)/(public)/Filters.svelte
+++ b/src/routes/(app)/(public)/Filters.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation'
-	import { page } from '$app/state'
 	import FilterForm from './FilterForm.svelte'
 
 	type Option = {
@@ -13,18 +11,8 @@
 	}
 
 	let { sort }: Props = $props()
-
-	let filters = $derived(page.url)
-
-	const updateSort = (value: string) => {
-		const url = new URL(filters)
-		if (value !== '') url.searchParams.set('sort', value)
-		else url.searchParams.delete('sort')
-
-		goto(url, { keepFocus: true })
-	}
 </script>
 
 <div class="mb-4 p-2 sm:p-0">
-	<FilterForm {sort} {filters} {updateSort} />
+	<FilterForm {sort} />
 </div>


### PR DESCRIPTION
## Summary
- Refactored Select component from bits-ui to native customizable `<select>` using `appearance: base-select` (Chrome 131+)
- Added `@supports` fallback styling for Safari compatibility with custom caret icon
- Created LinkSelect component for link-based dropdowns (no JavaScript needed)
- Replaced Sort dropdown with LinkSelect to be consistent with FilterDropdown
- Simplified admin select components (StatusSelect, TypeSelect) to reuse Select component
- Updated all pages using Select to support form field spread props

## Features
- Progressive enhancement - works without JavaScript
- Consistent UI across FilterDropdown, LinkSelect, and Select
- Cross-browser compatibility (native select in Safari, custom picker in Chrome)
- Keyboard navigation and accessibility support

🤖 Generated with [Claude Code](https://claude.com/claude-code)