### PR TITLE
Remove bits-ui from Pagination and improve filter dropdowns

### DIFF
--- a/src/lib/ui/Pagination.svelte
+++ b/src/lib/ui/Pagination.svelte
@@ -23,43 +23,32 @@
 		preserveParams = true
 	} = $props()
 
-	// Get the current page from the URL
 	let currentPage = $derived(parseInt(page.url.searchParams.get('page') || '1', 10))
-
-	// Calculate total pages and range for display
 	let totalPages = $derived(Math.ceil(count / perPage))
 	let rangeStart = $derived((currentPage - 1) * perPage + 1)
 	let rangeEnd = $derived(Math.min(currentPage * perPage, count))
 
-	// Calculate which page numbers to show
 	let pages = $derived.by(() => {
 		const result: (number | 'ellipsis')[] = []
-
-		// Always show first page
 		result.push(1)
 
-		// Calculate the range around current page
 		const leftSibling = Math.max(2, currentPage - siblingCount)
 		const rightSibling = Math.min(totalPages - 1, currentPage + siblingCount)
 
-		// Add left ellipsis if needed
 		if (leftSibling > 2) {
 			result.push('ellipsis')
 		}
 
-		// Add pages around current
 		for (let i = leftSibling; i <= rightSibling; i++) {
 			if (i !== 1 && i !== totalPages) {
 				result.push(i)
 			}
 		}
 
-		// Add right ellipsis if needed
 		if (rightSibling < totalPages - 1) {
 			result.push('ellipsis')
 		}
 
-		// Always show last page (if more than 1 page)
 		if (totalPages > 1) {
 			result.push(totalPages)
 		}
@@ -67,7 +56,6 @@
 		return result
 	})
 
-	// Build href for a given page number
 	function getPageHref(pageNum: number): string {
 		const url = new URL(page.url)
 		if (!preserveParams) {
@@ -77,20 +65,6 @@
 		return url.pathname + url.search
 	}
 </script>
-
-<!--
-@component
-A pagination component using native links for navigation.
-
-- Uses anchor tags for SEO and progressive enhancement
-- Preserves URL parameters when navigating between pages
-- Styled with custom Svelte colors
-
-Usage:
-```svelte
-<Pagination count={100} perPage={10} />
-```
--->
 
 <nav aria-label="Pagination">
 	<div class="my-8 flex items-center justify-center">

--- a/src/lib/ui/Pagination.svelte
+++ b/src/lib/ui/Pagination.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { Pagination } from 'bits-ui'
 	import { page } from '$app/state'
-	import { goto } from '$app/navigation'
 
 	let {
 		/**
@@ -28,30 +26,65 @@
 	// Get the current page from the URL
 	let currentPage = $derived(parseInt(page.url.searchParams.get('page') || '1', 10))
 
-	// Calculate the actual range for display
+	// Calculate total pages and range for display
+	let totalPages = $derived(Math.ceil(count / perPage))
 	let rangeStart = $derived((currentPage - 1) * perPage + 1)
 	let rangeEnd = $derived(Math.min(currentPage * perPage, count))
 
-	// Function to handle page change
-	function handlePageChange(pageNum: number) {
-		if (preserveParams) {
-			const url = new URL(page.url)
-			url.searchParams.set('page', pageNum.toString())
-			goto(url.toString())
-		} else {
-			goto(`?page=${pageNum}`)
+	// Calculate which page numbers to show
+	let pages = $derived.by(() => {
+		const result: (number | 'ellipsis')[] = []
+
+		// Always show first page
+		result.push(1)
+
+		// Calculate the range around current page
+		const leftSibling = Math.max(2, currentPage - siblingCount)
+		const rightSibling = Math.min(totalPages - 1, currentPage + siblingCount)
+
+		// Add left ellipsis if needed
+		if (leftSibling > 2) {
+			result.push('ellipsis')
 		}
+
+		// Add pages around current
+		for (let i = leftSibling; i <= rightSibling; i++) {
+			if (i !== 1 && i !== totalPages) {
+				result.push(i)
+			}
+		}
+
+		// Add right ellipsis if needed
+		if (rightSibling < totalPages - 1) {
+			result.push('ellipsis')
+		}
+
+		// Always show last page (if more than 1 page)
+		if (totalPages > 1) {
+			result.push(totalPages)
+		}
+
+		return result
+	})
+
+	// Build href for a given page number
+	function getPageHref(pageNum: number): string {
+		const url = new URL(page.url)
+		if (!preserveParams) {
+			url.search = ''
+		}
+		url.searchParams.set('page', String(pageNum))
+		return url.pathname + url.search
 	}
 </script>
 
 <!--
 @component
-A pagination component built with Bits UI.
+A pagination component using native links for navigation.
 
-- Uses the Bits UI Pagination component
+- Uses anchor tags for SEO and progressive enhancement
 - Preserves URL parameters when navigating between pages
 - Styled with custom Svelte colors
-- Uses SvelteKit's goto for client-side navigation
 
 Usage:
 ```svelte
@@ -59,17 +92,13 @@ Usage:
 ```
 -->
 
-<Pagination.Root
-	{count}
-	{perPage}
-	{siblingCount}
-	page={currentPage}
-	onPageChange={handlePageChange}
->
-	{#snippet children({ pages, range })}
-		<div class="my-8 flex items-center justify-center">
-			<Pagination.PrevButton
-				class="mr-4 inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:disabled:bg-transparent"
+<nav aria-label="Pagination">
+	<div class="my-8 flex items-center justify-center">
+		{#if currentPage > 1}
+			<a
+				href={getPageHref(currentPage - 1)}
+				class="mr-4 inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 active:scale-[0.98]"
+				aria-label="Previous page"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -84,25 +113,55 @@ Usage:
 				>
 					<path d="m15 18-6-6 6-6" />
 				</svg>
-			</Pagination.PrevButton>
+			</a>
+		{:else}
+			<span
+				class="mr-4 inline-flex h-9 w-9 cursor-not-allowed items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 opacity-50"
+				aria-disabled="true"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="m15 18-6-6 6-6" />
+				</svg>
+			</span>
+		{/if}
 
-			<div class="flex items-center gap-2">
-				{#each pages as page (page.key)}
-					{#if page.type === 'ellipsis'}
-						<div class="text-sm font-medium text-gray-500 select-none">...</div>
-					{:else}
-						<Pagination.Page
-							{page}
-							class="data-selected:border-svelte-900 data-selected:bg-svelte-900 inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium select-none hover:bg-gray-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:disabled:bg-transparent data-selected:text-white"
-						>
-							{page.value}
-						</Pagination.Page>
-					{/if}
-				{/each}
-			</div>
+		<div class="flex items-center gap-2">
+			{#each pages as item, index (item === 'ellipsis' ? `ellipsis-${index}` : item)}
+				{#if item === 'ellipsis'}
+					<span class="text-sm font-medium text-gray-500 select-none">...</span>
+				{:else if item === currentPage}
+					<span
+						class="border-svelte-900 bg-svelte-900 inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium text-white select-none"
+						aria-current="page"
+					>
+						{item}
+					</span>
+				{:else}
+					<a
+						href={getPageHref(item)}
+						class="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium select-none hover:bg-gray-50 active:scale-[0.98]"
+					>
+						{item}
+					</a>
+				{/if}
+			{/each}
+		</div>
 
-			<Pagination.NextButton
-				class="ml-4 inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:disabled:bg-transparent"
+		{#if currentPage < totalPages}
+			<a
+				href={getPageHref(currentPage + 1)}
+				class="ml-4 inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 active:scale-[0.98]"
+				aria-label="Next page"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -117,14 +176,33 @@ Usage:
 				>
 					<path d="m9 18 6-6-6-6" />
 				</svg>
-			</Pagination.NextButton>
-		</div>
-		<p class="text-center text-sm text-gray-500">
-			{#if count > 0}
-				Showing {rangeStart} - {rangeEnd} of {count}
-			{:else}
-				No items to display
-			{/if}
-		</p>
-	{/snippet}
-</Pagination.Root>
+			</a>
+		{:else}
+			<span
+				class="ml-4 inline-flex h-9 w-9 cursor-not-allowed items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 opacity-50"
+				aria-disabled="true"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="m9 18 6-6-6-6" />
+				</svg>
+			</span>
+		{/if}
+	</div>
+	<p class="text-center text-sm text-gray-500">
+		{#if count > 0}
+			Showing {rangeStart} - {rangeEnd} of {count}
+		{:else}
+			No items to display
+		{/if}
+	</p>
+</nav>

--- a/src/lib/ui/filter/FilterSubmenu.svelte
+++ b/src/lib/ui/filter/FilterSubmenu.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import CaretRight from 'phosphor-svelte/lib/CaretRight'
+	import CaretUp from 'phosphor-svelte/lib/CaretUp'
+	import CaretDown from 'phosphor-svelte/lib/CaretDown'
 	import Check from 'phosphor-svelte/lib/Check'
 	import { page } from '$app/state'
 	import { buildToggleHref, isValueActive } from './url-helpers'
@@ -95,31 +97,47 @@
 		<span class="sr-only">Open submenu</span>
 	</div>
 	<div
-		role="menu"
-		aria-label="{label} options"
-		bind:this={submenuEl}
-		class="invisible absolute left-full top-0 ml-1 min-w-44 rounded-xl bg-white px-1 py-3 opacity-0 shadow-2xl transition-all select-none group-focus-within/submenu:visible group-focus-within/submenu:opacity-100"
+		class="group/menu invisible absolute left-full top-0 ml-1 min-w-44 rounded-xl bg-white shadow-2xl opacity-0 transition-all select-none group-focus-within/submenu:visible group-focus-within/submenu:opacity-100"
 	>
-		{#each await fetchItems() as item (item.value)}
-			{@const isActive = isValueActive(page.url, paramName, item.value)}
-			<a
-				href={buildToggleHref(page.url, page.route.id, page.params, paramName, item.value)}
-				role="menuitemcheckbox"
-				aria-checked={isActive}
-				onclick={() => onSelect?.()}
-				onkeydown={(e) => {
-					if (e.key === ' ') {
-						e.preventDefault()
-						e.currentTarget.click()
-					}
-				}}
-				class="flex h-8 w-full items-center justify-between rounded-sm py-3 pr-2 pl-3 text-sm outline-hidden hover:bg-gray-100 focus:bg-gray-100"
-			>
-				{item.label}
-				{#if isActive}
-					<Check class="size-4 text-svelte-500" weight="bold" />
-				{/if}
-			</a>
-		{/each}
+		<div
+			class="hidden items-center justify-center py-2 text-gray-400 group-has-[:nth-child(15)]/menu:flex"
+			aria-hidden="true"
+		>
+			<CaretUp class="size-4" />
+		</div>
+		<div
+			role="menu"
+			aria-label="{label} options"
+			bind:this={submenuEl}
+			class="max-h-[500px] overflow-y-auto px-1 group-has-[:nth-child(15)]/menu:py-1 py-3"
+		>
+			{#each await fetchItems() as item (item.value)}
+				{@const isActive = isValueActive(page.url, paramName, item.value)}
+				<a
+					href={buildToggleHref(page.url, page.route.id, page.params, paramName, item.value)}
+					role="menuitemcheckbox"
+					aria-checked={isActive}
+					onclick={() => onSelect?.()}
+					onkeydown={(e) => {
+						if (e.key === ' ') {
+							e.preventDefault()
+							e.currentTarget.click()
+						}
+					}}
+					class="flex h-8 w-full items-center justify-between rounded-sm py-3 pr-2 pl-3 text-sm outline-hidden hover:bg-gray-100 focus:bg-gray-100"
+				>
+					{item.label}
+					{#if isActive}
+						<Check class="size-4 text-svelte-500" weight="bold" />
+					{/if}
+				</a>
+			{/each}
+		</div>
+		<div
+			class="hidden items-center justify-center py-2 text-gray-400 group-has-[:nth-child(15)]/menu:flex"
+			aria-hidden="true"
+		>
+			<CaretDown class="size-4" />
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
Replace bits-ui Pagination component with custom link-based implementation. Add max-height scrolling and CSS-only scroll indicators to filter dropdown submenus.

- Pagination uses native anchor tags for SEO and progressive enhancement
- Filter dropdowns (Tags, Authors) scroll at 500px with caret icons indicating more items
- No JavaScript needed for scroll indication - pure CSS/HTML solution