### PR TITLE
Fix omni search suggestion click handler

### DIFF
--- a/src/routes/(app)/_components/OmniSearch.svelte
+++ b/src/routes/(app)/_components/OmniSearch.svelte
@@ -183,7 +183,11 @@
 							bind:this={suggestionRefs[i]}
 							href={buildAddFilterHref(suggestion)}
 							onpointerdown={(e) => e.preventDefault()}
-							onclick={clearSearch}
+							onclick={(e) => {
+								e.preventDefault()
+								goto(buildAddFilterHref(suggestion), { keepFocus: true })
+								clearSearch()
+							}}
 							onkeydown={handleKeydown}
 							onfocus={() => handleFocus(suggestion)}
 							class="flex items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-svelte-50 focus:bg-svelte-100 focus:outline-none {isSelected(suggestion) ? 'bg-svelte-100' : ''}"


### PR DESCRIPTION
## Problem
Clicking a suggestion in the omni search component raised a TypeError because the click handler cleared the search state before navigation completed, causing a race condition that invalidated the suggestion reference.

## Solution
Updated the click handler to explicitly call `goto()` with the suggestion's href before clearing search state, matching the keyboard Enter behavior and eliminating the race condition.

## Testing
- Keyboard Enter: Already working (unchanged)
- Click suggestions: Now works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)