### PR TITLE
Fix filter close button double-click issue

### DIFF
--- a/src/lib/ui/Dropdown.svelte
+++ b/src/lib/ui/Dropdown.svelte
@@ -159,7 +159,7 @@
 		aria-label={menuLabel}
 		bind:this={menuEl}
 		ontouchstart={() => {}}
-		class="invisible absolute top-full z-50 mt-1 cursor-pointer opacity-0 touch-manipulation transition-[visibility] select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100 group-data-[force-closed]/dropdown:opacity-0 group-data-[force-closed]/dropdown:pointer-events-none {alignmentClass} {menuClass}"
+		class="invisible pointer-events-none absolute top-full z-50 mt-1 cursor-pointer opacity-0 touch-manipulation transition-[visibility] select-none group-focus-within/dropdown:visible group-focus-within/dropdown:opacity-100 group-focus-within/dropdown:pointer-events-auto group-data-[force-closed]/dropdown:opacity-0 group-data-[force-closed]/dropdown:pointer-events-none {alignmentClass} {menuClass}"
 	>
 		{@render children()}
 	</div>


### PR DESCRIPTION
## Summary
Invisible dropdown menu was capturing clicks due to z-50 positioning. Added pointer-events-none by default and pointer-events-auto only when visible, allowing single-click removal of active filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)