### PR TITLE
Prioritize 16:9 YouTube thumbnails

### DIFF
--- a/src/lib/server/services/metadata.ts
+++ b/src/lib/server/services/metadata.ts
@@ -99,7 +99,12 @@ export class MetadataService {
 				title: snippet.title || '',
 				description: snippet.description || '',
 				duration: contentDetails.duration || '', // ISO 8601 duration format
-				thumbnail: snippet.thumbnails?.high?.url || snippet.thumbnails?.default?.url || '',
+				thumbnail:
+					snippet.thumbnails?.maxres?.url ||
+					snippet.thumbnails?.medium?.url ||
+					snippet.thumbnails?.high?.url ||
+					snippet.thumbnails?.default?.url ||
+					'',
 				publishedAt: snippet.publishedAt || ''
 			}
 		} catch (error) {

--- a/src/routes/(api)/api/preview/youtube/+server.ts
+++ b/src/routes/(api)/api/preview/youtube/+server.ts
@@ -65,9 +65,9 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 		const bestThumbnail =
 			video.snippet.thumbnails.maxres ||
-			video.snippet.thumbnails.standard ||
-			video.snippet.thumbnails.high ||
 			video.snippet.thumbnails.medium ||
+			video.snippet.thumbnails.high ||
+			video.snippet.thumbnails.standard ||
 			video.snippet.thumbnails.default
 
 		return json({

--- a/src/routes/(app)/(public)/submit/submit.remote.ts
+++ b/src/routes/(app)/(public)/submit/submit.remote.ts
@@ -171,7 +171,7 @@ export const submitVideo = form(videoSchema, async (data) => {
 				metadata: {
 					embedUrl: `https://www.youtube.com/embed/${videoId}`,
 					watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
-					thumbnail: thumbnail || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+					thumbnail: thumbnail || `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`,
 					youtubeVideoId: videoId,
 					submitter_notes: data.notes || '',
 					submitted_at: new Date().toISOString()


### PR DESCRIPTION
## Summary
Update thumbnail selection across YouTube metadata endpoints to prefer 16:9 aspect ratio formats (maxres at 1280×720, medium at 320×180) over 4:3 formats (high at 480×360, standard at 640×480). Also changes the CDN fallback from hqdefault.jpg (4:3) to mqdefault.jpg (16:9).

## Changes
- **metadata.ts**: Reorder thumbnail selection to prioritize maxres and medium
- **api/preview/youtube**: Reorder fallback chain to check medium before high
- **submit.remote.ts**: Change fallback URL from hqdefault to mqdefault

The changes ensure consistent 16:9 aspect ratio thumbnails across all submission and preview flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)