### PR TITLE
Redesign right sidebar with header action buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Required environment variables
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+# Required environment variables (dummy values work for local dev, replace for OAuth to work)
+GITHUB_CLIENT_ID=dummy_client_id
+GITHUB_CLIENT_SECRET=dummy_client_secret
 GITHUB_AUTHORIZATION_CALLBACK_URL=http://localhost:5173/auth/callback
 DB_PATH=local.db
 
@@ -25,10 +25,10 @@ USE_S3_THUMBNAILS=false           # Enable S3 storage for thumbnails (set to 'tr
 # Analytics (optional)
 PUBLIC_PLAUSIBLE_SHARED_LINK_AUTH=  # Plausible analytics shared link auth token
 
-# Job Board - Stripe (required for paid job postings)
-STRIPE_SECRET_KEY=                  # Stripe secret key (sk_test_... or sk_live_...)
-STRIPE_WEBHOOK_SECRET=              # Stripe webhook signing secret (whsec_...)
-PUBLIC_STRIPE_PUBLISHABLE_KEY=      # Stripe publishable key (pk_test_... or pk_live_...)
+# Job Board - Stripe (dummy values work for local dev, replace for payments to work)
+STRIPE_SECRET_KEY=sk_test_dummy_key_for_local_development
+STRIPE_WEBHOOK_SECRET=whsec_dummy_webhook_secret
+PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_dummy_publishable_key
 
 # Job Board - Plunk Email (required for job notifications)
 PLUNK_API_SECRET_KEY=               # Plunk secret API key (sk_...) for transactional emails

--- a/src/lib/ui/NewsletterSubscribe.svelte
+++ b/src/lib/ui/NewsletterSubscribe.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from './Button.svelte'
+	import SidebarCard from './SidebarCard.svelte'
 	import { Envelope, CheckCircle, Warning } from 'phosphor-svelte'
 	import { subscribeNewsletter } from './newsletter.remote'
 
@@ -7,14 +8,10 @@
 	let errorMessage = $state('')
 </script>
 
-<div
-	class="grid gap-2 rounded border border-slate-200 bg-gray-50 px-4 py-3 text-sm"
-	data-testid="newsletter-subscribe"
->
-	<div class="flex items-center gap-2">
+<SidebarCard title="Newsletter" padding="compact" data-testid="newsletter-subscribe">
+	{#snippet icon()}
 		<Envelope weight="bold" class="text-orange-600" />
-		<h3 class="font-bold">Newsletter</h3>
-	</div>
+	{/snippet}
 
 	{#if showSuccess}
 		<div class="flex items-center gap-2 text-green-600" data-testid="newsletter-success">
@@ -65,4 +62,4 @@
 			</Button>
 		</form>
 	{/if}
-</div>
+</SidebarCard>

--- a/src/lib/ui/SidebarCard.svelte
+++ b/src/lib/ui/SidebarCard.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+	import type { ClassValue, HTMLAttributes } from 'svelte/elements'
+	import { sidebarCardVariants, type SidebarCardPadding } from './sidebarCard.variants'
+
+	type Props = {
+		title: string
+		padding?: SidebarCardPadding
+		class?: ClassValue
+		icon?: Snippet
+		action?: Snippet
+		children: Snippet
+		footer?: Snippet
+	} & HTMLAttributes<HTMLDivElement>
+
+	let { title, padding, class: className, icon, action, children, footer, ...rest }: Props = $props()
+</script>
+
+<div class={[sidebarCardVariants({ padding }), className]} {...rest}>
+	<div class="flex items-center justify-between">
+		<div class="flex items-center gap-2">
+			{#if icon}
+				{@render icon()}
+			{/if}
+			<h3 class="text-md font-bold">{title}</h3>
+		</div>
+		{#if action}
+			{@render action()}
+		{/if}
+	</div>
+
+	{@render children()}
+
+	{#if footer}
+		<div class="text-right">
+			{@render footer()}
+		</div>
+	{/if}
+</div>

--- a/src/lib/ui/sidebarCard.variants.ts
+++ b/src/lib/ui/sidebarCard.variants.ts
@@ -1,0 +1,16 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const sidebarCardVariants = tv({
+	base: 'grid gap-3 rounded border border-slate-200 bg-gray-50 p-4',
+	variants: {
+		padding: {
+			default: 'p-4',
+			compact: 'px-4 py-3'
+		}
+	},
+	defaultVariants: {
+		padding: 'default'
+	}
+})
+
+export type SidebarCardPadding = VariantProps<typeof sidebarCardVariants>['padding']

--- a/src/routes/(app)/_components/RightSidebar.svelte
+++ b/src/routes/(app)/_components/RightSidebar.svelte
@@ -34,11 +34,11 @@
 
 	<SidebarSponsors {sponsors} />
 
-	{#if user?.newsletter_preference !== 'subscribed'}
-		<NewsletterSubscribe />
-	{/if}
-
 	<SidebarJobs {jobs} />
 
 	<UpcomingEvents events={upcomingEvents} />
+
+	{#if user?.newsletter_preference !== 'subscribed'}
+		<NewsletterSubscribe />
+	{/if}
 </aside>

--- a/src/routes/(app)/_components/SidebarJobs.svelte
+++ b/src/routes/(app)/_components/SidebarJobs.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import Briefcase from 'phosphor-svelte/lib/Briefcase'
 	import MapPin from 'phosphor-svelte/lib/MapPin'
+	import Plus from 'phosphor-svelte/lib/Plus'
 	import Star from 'phosphor-svelte/lib/Star'
 	import { type SidebarJob } from './types'
 	import { getCachedImageWithPreset } from '$lib/utils/image-cache'
 	import { formatSalaryCompact } from '$lib/utils/job-formatters'
+	import SidebarCard from '$lib/ui/SidebarCard.svelte'
+	import Button from '$lib/ui/Button.svelte'
 
 	let { jobs = [] }: { jobs?: SidebarJob[] } = $props()
 
@@ -14,82 +17,104 @@
 		'on-site': 'On-Site'
 	}
 
+	// Max slots to show (3 total: jobs + placeholders)
+	const MAX_SLOTS = 3
+	const placeholderCount = $derived(Math.max(0, MAX_SLOTS - jobs.length))
+
 	const isPremium = (tierName?: string) => tierName?.toLowerCase() === 'premium'
 </script>
 
-<div class="grid gap-3 rounded border border-slate-200 bg-gray-50 p-4">
-	<div class="flex items-center justify-between">
-		<h3 class="text-md font-bold">Jobs</h3>
-		{#if jobs && jobs.length > 0}
-			<a href="/job" class="text-svelte-500 text-xs hover:underline" data-sveltekit-preload-data="off"
-				>View all</a
-			>
-		{/if}
-	</div>
-	{#if jobs && jobs.length > 0}
-		<div class="space-y-3">
-			{#each jobs as job}
-				{@const salary = formatSalaryCompact(job.salary_min, job.salary_max, job.salary_currency)}
-				<div class="grid grid-cols-[auto_1fr] gap-3">
-					<!-- Logo column -->
-					{#if job.company_logo}
-						<img
-							src={getCachedImageWithPreset(job.company_logo, 'thumbnail')}
-							alt="{job.company_name} logo"
-							class="h-10 w-10 rounded border border-slate-200 bg-white object-contain"
-						/>
-					{:else}
-						<div
-							class="flex h-10 w-10 items-center justify-center rounded border border-slate-200 bg-white"
+<SidebarCard title="Jobs">
+	{#snippet action()}
+		<Button href="/jobs/submit" variant="secondary" size="thin" data-sveltekit-preload-data="off">
+			<Plus size={12} />
+			Post
+		</Button>
+	{/snippet}
+
+	<div class="space-y-3">
+		{#each jobs as job (job.id)}
+			{@const salary = formatSalaryCompact(job.salary_min, job.salary_max, job.salary_currency)}
+			<div class="grid grid-cols-[auto_1fr] gap-3">
+				<!-- Logo column -->
+				{#if job.company_logo}
+					<img
+						src={getCachedImageWithPreset(job.company_logo, 'thumbnail')}
+						alt="{job.company_name} logo"
+						class="h-10 w-10 rounded border border-slate-200 bg-white object-contain"
+					/>
+				{:else}
+					<div
+						class="flex h-10 w-10 items-center justify-center rounded border border-slate-200 bg-white"
+					>
+						<Briefcase size={20} class="text-slate-400" />
+					</div>
+				{/if}
+				<!-- Content column -->
+				<div class="min-w-0">
+					<h4 class="truncate text-sm font-semibold">
+						<a
+							href="/job/{job.slug}"
+							class="hover:text-svelte-500"
+							data-sveltekit-preload-data="off"
 						>
-							<Briefcase size={20} class="text-slate-400" />
-						</div>
-					{/if}
-					<!-- Content column -->
-					<div class="min-w-0">
-						<h4 class="truncate text-sm font-semibold">
-							<a
-								href="/job/{job.slug}"
-								class="hover:text-svelte-500"
-								data-sveltekit-preload-data="off"
-							>
-								{job.title}
-							</a>
-							{#if isPremium(job.tier_name)}
-								<Star size={12} weight="fill" class="ml-1 inline-block text-amber-500" />
-							{/if}
-						</h4>
-						<p class="truncate text-xs text-gray-600">{job.company_name}</p>
-						<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
-							<span
-								class="rounded bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium uppercase"
-							>
-								{remoteLabels[job.remote_status] || job.remote_status}
+							{job.title}
+						</a>
+						{#if isPremium(job.tier_name)}
+							<Star size={12} weight="fill" class="ml-1 inline-block text-amber-500" />
+						{/if}
+					</h4>
+					<p class="truncate text-xs text-gray-600">{job.company_name}</p>
+					<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+						<span
+							class="rounded bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium uppercase"
+						>
+							{remoteLabels[job.remote_status] || job.remote_status}
+						</span>
+						{#if job.location}
+							<span class="flex items-center gap-0.5">
+								<MapPin size={10} />
+								<span class="truncate">{job.location}</span>
 							</span>
-							{#if job.location}
-								<span class="flex items-center gap-0.5">
-									<MapPin size={10} />
-									<span class="truncate">{job.location}</span>
-								</span>
-							{/if}
-							{#if salary}
-								<span class="text-green-600">{salary}</span>
-							{/if}
-						</div>
+						{/if}
+						{#if salary}
+							<span class="text-green-600">{salary}</span>
+						{/if}
 					</div>
 				</div>
-			{/each}
-		</div>
-	{:else}
-		<p class="text-xs text-gray-600">
-			Reach thousands of Svelte developers by posting your job here.
-		</p>
-	{/if}
-	<a
-		href="/jobs/submit"
-		class="mt-1 block rounded bg-orange-500 px-3 py-1.5 text-center text-xs font-medium text-white transition-colors hover:bg-orange-600"
-		data-sveltekit-preload-data="off"
-	>
-		Post a Job
-	</a>
-</div>
+			</div>
+		{/each}
+
+		{#each Array(placeholderCount) as _, i (i)}
+			<a
+				href="/jobs/submit"
+				class="group grid grid-cols-[auto_1fr] gap-3 rounded border border-dashed border-slate-300 bg-white p-2 transition-colors hover:border-svelte-400 hover:bg-svelte-50"
+				data-sveltekit-preload-data="off"
+			>
+				<!-- Placeholder logo -->
+				<div
+					class="flex h-10 w-10 items-center justify-center rounded border border-dashed border-slate-300 bg-slate-50 transition-colors group-hover:border-svelte-400 group-hover:bg-svelte-100"
+				>
+					<Plus size={16} class="text-slate-400 transition-colors group-hover:text-svelte-500" />
+				</div>
+				<!-- Placeholder content -->
+				<div class="flex flex-col justify-center">
+					<span
+						class="text-xs font-medium text-slate-400 transition-colors group-hover:text-svelte-600"
+					>
+						Post your job here
+					</span>
+					<span class="text-[10px] text-slate-400">Reach Svelte developers</span>
+				</div>
+			</a>
+		{/each}
+	</div>
+
+	{#snippet footer()}
+		{#if jobs && jobs.length > 0}
+			<a href="/job" class="text-svelte-500 text-xs hover:underline" data-sveltekit-preload-data="off">
+				View all →
+			</a>
+		{/if}
+	{/snippet}
+</SidebarCard>

--- a/src/routes/(app)/_components/SidebarSponsors.svelte
+++ b/src/routes/(app)/_components/SidebarSponsors.svelte
@@ -4,6 +4,8 @@
 	import Tag from 'phosphor-svelte/lib/Tag'
 	import { type SidebarSponsor } from './types'
 	import { getCachedImageWithPreset } from '$lib/utils/image-cache'
+	import SidebarCard from '$lib/ui/SidebarCard.svelte'
+	import Button from '$lib/ui/Button.svelte'
 
 	let { sponsors = [] }: { sponsors?: SidebarSponsor[] } = $props()
 
@@ -13,11 +15,13 @@
 	const isPremium = (logoSize?: string) => logoSize === 'large'
 </script>
 
-<div class="grid gap-3 rounded border border-slate-200 bg-gray-50 p-4">
-	<div class="flex items-center justify-between">
-		<h3 class="text-md font-bold">Sponsors</h3>
-		<a href="/sponsors/submit" class="text-svelte-500 text-xs hover:underline">Learn more</a>
-	</div>
+<SidebarCard title="Sponsors">
+	{#snippet action()}
+		<Button href="/sponsors/submit" variant="secondary" size="thin">
+			<Plus size={12} />
+			Sponsor
+		</Button>
+	{/snippet}
 
 	<div class="space-y-2">
 		{#each sponsors as sponsor (sponsor.id)}
@@ -101,15 +105,4 @@
 			</a>
 		{/each}
 	</div>
-
-	<p class="text-xs text-gray-600">
-		Support Svelte Society and get your company featured to thousands of developers.
-	</p>
-
-	<a
-		href="/sponsors/submit"
-		class="mt-1 block rounded bg-orange-500 px-3 py-1.5 text-center text-xs font-medium text-white transition-colors hover:bg-orange-600"
-	>
-		Become a Sponsor
-	</a>
-</div>
+</SidebarCard>

--- a/src/routes/(app)/_components/UpcomingEvents.svelte
+++ b/src/routes/(app)/_components/UpcomingEvents.svelte
@@ -3,19 +3,14 @@
 	import MapPin from 'phosphor-svelte/lib/MapPin'
 	import User from 'phosphor-svelte/lib/User'
 	import { type UpcomingEvent } from './types'
+	import SidebarCard from '$lib/ui/SidebarCard.svelte'
 
 	let { events = [], onLinkClick }: { events?: UpcomingEvent[]; onLinkClick?: () => void } =
 		$props()
 </script>
 
 {#if events && events.length > 0}
-	<div class="grid gap-3 rounded border border-slate-200 bg-gray-50 p-4">
-		<div class="flex items-center justify-between">
-			<h3 class="text-md font-bold">Upcoming Events</h3>
-			<a href="/events" class="text-svelte-500 text-xs hover:underline" onclick={onLinkClick}
-				>View all</a
-			>
-		</div>
+	<SidebarCard title="Upcoming Events">
 		<div class="space-y-3">
 			{#each events as event}
 				<div class="border-svelte-300 border-l-2 pl-3">
@@ -73,5 +68,11 @@
 				</div>
 			{/each}
 		</div>
-	</div>
+
+		{#snippet footer()}
+			<a href="/events" class="text-svelte-500 text-xs hover:underline" onclick={onLinkClick}>
+				View all →
+			</a>
+		{/snippet}
+	</SidebarCard>
 {/if}


### PR DESCRIPTION
## Summary

- Create reusable SidebarCard component with flexible slot-based layout (icon, action, footer)
- Add header action buttons (+ Post, + Sponsor) to Jobs and Sponsors cards using secondary Button variant
- Move navigation links (View all) to footer for consistent card layout
- Add placeholder slots for Jobs and Sponsors cards (up to 3 total showing jobs/sponsors + placeholders)
- Refactor Newsletter card to use new SidebarCard component
- Reorder sidebar cards: Sponsors → Jobs → Events → Newsletter (newsletter moved to bottom)
- Update .env.example with dummy credentials for local development

## Test Plan

- [ ] Verify sidebar displays all cards in correct order on desktop (sm+ breakpoint)
- [ ] Check that action buttons have proper styling and link to correct pages (/jobs/submit, /sponsors/submit)
- [ ] Verify placeholder slots appear when fewer than 3 jobs/sponsors available
- [ ] Test hover states on buttons and placeholder items
- [ ] Confirm newsletter card appears at bottom (only if user not subscribed)
- [ ] Run dev server and check responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)