### PR TITLE
Update organization number in terms of service

### DIFF
--- a/src/routes/(app)/terms/+page.svelte
+++ b/src/routes/(app)/terms/+page.svelte
@@ -7,7 +7,7 @@
 
 	<div class="prose prose-slate max-w-none">
 		<p class="mb-6 text-slate-600">
-			Svelte Society is operated by Svelte School AB, a Swedish company (org. nr 559292-4793). By
+			Svelte Society is operated by Svelte School AB, a Swedish company (org. nr 559260-8987). By
 			using our services or making purchases, you are entering into an agreement with Svelte School
 			AB.
 		</p>


### PR DESCRIPTION
Updated the organization number (org. nr) from 559292-4793 to 559260-8987 in the terms of service page to reflect the correct organization registration.

## Changes
- Updated org. nr in Terms of Service page

🤖 Generated with Claude Code