### PR TITLE
Enable discount codes for purchases

### DIFF
--- a/src/lib/server/services/payments/stripe.ts
+++ b/src/lib/server/services/payments/stripe.ts
@@ -78,6 +78,7 @@ export class StripeService {
 			cancel_url: cancelUrl,
 			automatic_tax: { enabled: true },
 			tax_id_collection: { enabled: true },
+			allow_promotion_codes: true,
 			metadata: {
 				tier_id: tier.id,
 				tier_name: tier.name,
@@ -172,6 +173,7 @@ export class StripeService {
 			cancel_url: cancelUrl,
 			automatic_tax: { enabled: true },
 			tax_id_collection: { enabled: true },
+			allow_promotion_codes: true,
 			invoice_creation: {
 				enabled: true,
 				invoice_data: {


### PR DESCRIPTION
Enable discount codes for sponsor and job posting purchases via Stripe Checkout.

This adds the `allow_promotion_codes: true` parameter to both checkout session creation methods, allowing customers to enter discount codes at checkout. Coupons can be created and managed in the Stripe Dashboard.

## Testing
- Create a test coupon in Stripe Dashboard
- Submit a job posting or sponsorship and verify the "Add promotion code" field appears on checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)