### PR TITLE
Hide description on announcement detail pages

### DIFF
--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -264,7 +264,7 @@
 				>
 			{/if}
 		</h2>
-		{#if content.description && !(variant === 'detail' && content.type === 'recipe') && content.type !== 'resource'}
+		{#if content.description && !(variant === 'detail' && (content.type === 'recipe' || content.type === 'announcement')) && content.type !== 'resource'}
 			<div data-testid="content-description" class={descriptionVariants({ variant, compact })}>
 				{content.description}
 			</div>

--- a/src/routes/(app)/_components/Header.svelte
+++ b/src/routes/(app)/_components/Header.svelte
@@ -76,7 +76,7 @@
 </header>
 {#if announcement}
 	<div
-		class="bg-svelte-900 sticky top-20 z-10 flex w-full place-content-center p-2"
+		class="bg-svelte-900 sticky top-20 z-0 flex w-full place-content-center p-2"
 		style:view-transition-name="announcement"
 	>
 		<a href={announcement.href} class="text-semibold mx-auto text-white underline">


### PR DESCRIPTION
Announcements display their full body content on detail pages, but the short description was also being shown, resulting in duplicate content. This adds announcement to the conditional exclusion that already applies to recipes.

- Only affects detail page display
- Announcements still show description on list pages
- Matches existing pattern for recipe content type