### PR TITLE
Fix Stripe webhook async issue and S3 upload error handling

### DIFF
--- a/src/lib/server/services/payments/stripe.ts
+++ b/src/lib/server/services/payments/stripe.ts
@@ -244,12 +244,12 @@ export class StripeService {
 	/**
 	 * Construct and verify a webhook event from the raw body and signature
 	 */
-	constructWebhookEvent(
+	async constructWebhookEvent(
 		payload: string | Buffer,
 		signature: string,
 		webhookSecret: string = STRIPE_WEBHOOK_SECRET
-	): Stripe.Event {
-		return this.stripe.webhooks.constructEvent(payload, signature, webhookSecret)
+	): Promise<Stripe.Event> {
+		return await this.stripe.webhooks.constructEventAsync(payload, signature, webhookSecret)
 	}
 
 	/**

--- a/src/lib/server/services/s3-storage.ts
+++ b/src/lib/server/services/s3-storage.ts
@@ -167,26 +167,21 @@ export async function thumbnailExists(key: string): Promise<boolean> {
  *
  * @param file - File object to upload
  * @param keyPrefix - Prefix for the S3 key (e.g., 'jobs/company-name')
- * @returns Public URL of the uploaded file, or null if upload fails or S3 is disabled
+ * @returns Public URL of the uploaded file
+ * @throws Error if S3 is disabled or upload fails
  *
  * @example
  * const url = await uploadImageFile(logoFile, 'jobs/acme-inc')
  * // Returns: 'https://thumbnails.yourdomain.com/jobs/acme-inc-1234567890/logo.png'
  */
-export async function uploadImageFile(file: File, keyPrefix: string): Promise<string | null> {
+export async function uploadImageFile(file: File, keyPrefix: string): Promise<string> {
 	if (!isS3Enabled) {
-		console.warn('S3 storage is not enabled. File will not be uploaded.')
-		return null
+		throw new Error('S3 storage is not enabled. Set USE_S3_THUMBNAILS=true to enable.')
 	}
 
-	try {
-		const ext = file.type.split('/')[1] || 'png'
-		const arrayBuffer = await file.arrayBuffer()
-		const timestamp = Date.now()
-		const key = `${keyPrefix}-${timestamp}/logo.${ext}`
-		return await uploadThumbnail(key, arrayBuffer)
-	} catch (error) {
-		console.error('Error uploading file to S3:', error)
-		return null
-	}
+	const ext = file.type.split('/')[1] || 'png'
+	const arrayBuffer = await file.arrayBuffer()
+	const timestamp = Date.now()
+	const key = `${keyPrefix}-${timestamp}/logo.${ext}`
+	return await uploadThumbnail(key, arrayBuffer)
 }

--- a/src/routes/(api)/api/webhooks/stripe/+server.ts
+++ b/src/routes/(api)/api/webhooks/stripe/+server.ts
@@ -13,7 +13,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 	let event: Stripe.Event
 	try {
-		event = locals.stripeService.constructWebhookEvent(payload, signature)
+		event = await locals.stripeService.constructWebhookEvent(payload, signature)
 	} catch (err) {
 		console.error('Webhook signature verification failed:', err)
 		return json({ error: 'Webhook signature verification failed' }, { status: 400 })

--- a/src/routes/(app)/(public)/jobs/submit/submit.remote.ts
+++ b/src/routes/(app)/(public)/jobs/submit/submit.remote.ts
@@ -31,10 +31,18 @@ export const submitJob = form(jobSubmissionSchema, async (data: JobSubmissionDat
 	// Upload company logo to S3 if provided
 	let companyLogoUrl: string | null = null
 	if (data.company_logo) {
-		companyLogoUrl = await uploadImageFile(
-			data.company_logo,
-			`jobs/${generateSlug(data.company_name)}`
-		)
+		try {
+			companyLogoUrl = await uploadImageFile(
+				data.company_logo,
+				`jobs/${generateSlug(data.company_name)}`
+			)
+		} catch (error) {
+			console.error('Error uploading company logo:', error)
+			return fail(500, {
+				error: 'Upload failed',
+				message: 'Failed to upload company logo. Please try again.'
+			})
+		}
 	}
 
 	// Store job data in payment metadata (will be used after payment succeeds)


### PR DESCRIPTION
## Summary

Fixes two production issues reported during job payment flow:
1. **Stripe webhook failure**: Changed from synchronous `constructEvent()` to async `constructEventAsync()` to fix "SubtleCryptoProvider cannot be used in a synchronous context" error
2. **S3 upload failures**: Changed `uploadImageFile()` to throw errors instead of silently returning null, allowing proper error handling in job and sponsor submission forms

## Changes

- Make `StripeService.constructWebhookEvent()` async and use `constructEventAsync()`
- Update webhook handler to await the async call
- Change `uploadImageFile()` to throw errors instead of returning null
- Add proper error handling in job submission when logo upload fails

The S3 configuration needs to be verified in production (`USE_S3_THUMBNAILS=true` and S3 endpoint/credentials properly set).