### PR TITLE
Fix S3 upload error handling in Remote Functions

### DIFF
--- a/src/routes/(app)/(public)/jobs/submit/+page.svelte
+++ b/src/routes/(app)/(public)/jobs/submit/+page.svelte
@@ -265,6 +265,13 @@
 			</div>
 		</div>
 
+		<!-- Error Display -->
+		{#if submitJob.result && 'success' in submitJob.result && !submitJob.result.success}
+			<div class="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700" data-testid="submit-error">
+				{submitJob.result.error}
+			</div>
+		{/if}
+
 		<!-- Submit -->
 		<div class="flex items-center justify-between rounded-lg bg-slate-50 p-6">
 			<div>
@@ -282,9 +289,9 @@
 					>.
 				</p>
 			</div>
-			<Button data-testid="submit-job-button">
+			<Button data-testid="submit-job-button" disabled={!!submitJob.pending}>
 				<Briefcase size={18} class="mr-2" />
-				Continue to Payment
+				{submitJob.pending ? 'Processing...' : 'Continue to Payment'}
 			</Button>
 		</div>
 	</form>

--- a/src/routes/(app)/(public)/jobs/submit/submit.remote.ts
+++ b/src/routes/(app)/(public)/jobs/submit/submit.remote.ts
@@ -1,5 +1,5 @@
 import { getRequestEvent, query, form } from '$app/server'
-import { fail, redirect } from '@sveltejs/kit'
+import { redirect } from '@sveltejs/kit'
 import { jobSubmissionSchema, type JobSubmissionData } from './schema'
 import type { StoredJobData } from '$lib/server/services/jobs'
 import { uploadImageFile } from '$lib/server/services/s3-storage'
@@ -22,10 +22,10 @@ export const submitJob = form(jobSubmissionSchema, async (data: JobSubmissionDat
 	// Get the selected tier
 	const tier = locals.jobTierService.getTierById(data.tier_id)
 	if (!tier) {
-		return fail(400, {
-			error: 'Invalid tier',
-			message: 'The selected pricing tier is not valid.'
-		})
+		return {
+			success: false as const,
+			error: 'The selected pricing tier is not valid.'
+		}
 	}
 
 	// Upload company logo to S3 if provided
@@ -38,10 +38,10 @@ export const submitJob = form(jobSubmissionSchema, async (data: JobSubmissionDat
 			)
 		} catch (error) {
 			console.error('Error uploading company logo:', error)
-			return fail(500, {
-				error: 'Upload failed',
-				message: 'Failed to upload company logo. Please try again.'
-			})
+			return {
+				success: false as const,
+				error: 'Failed to upload company logo. Please try again.'
+			}
 		}
 	}
 
@@ -100,10 +100,10 @@ export const submitJob = form(jobSubmissionSchema, async (data: JobSubmissionDat
 		checkoutUrl = checkoutResult.url
 	} catch (error) {
 		console.error('Error creating checkout session:', error)
-		return fail(500, {
-			error: 'Checkout failed',
-			message: 'Failed to create checkout session. Please try again.'
-		})
+		return {
+			success: false as const,
+			error: 'Failed to create checkout session. Please try again.'
+		}
 	}
 
 	// Redirect to Stripe checkout (outside try/catch)


### PR DESCRIPTION
## Summary

Fixed DevalueError when S3 upload fails in job submission by replacing `fail()` with plain object returns in Remote Functions form handler.

## Changes

- Replace `fail()` calls with plain object returns (Remote Functions should not use SvelteKit's `fail()` which returns a non-serializable ActionFailure class)
- Add error display section to job submission form
- Add pending state feedback to submit button

## Notes

The `fail()` function is designed for traditional form actions, not Remote Functions. Remote Functions serialize their response with devalue, which cannot serialize class instances like ActionFailure.