### PR TITLE
Fix mobile cookie expiration issue

### DIFF
--- a/src/routes/(api)/auth/callback/+server.ts
+++ b/src/routes/(api)/auth/callback/+server.ts
@@ -74,7 +74,8 @@ export const GET: RequestHandler = async ({ url, cookies, locals }) => {
 		cookies.set('session_id', session_token, {
 			path: '/',
 			httpOnly: true,
-			secure: !dev
+			secure: !dev,
+			maxAge: 7 * 24 * 60 * 60 // 7 days in seconds
 		})
 
 		// Create a manual redirect response with appropriate headers


### PR DESCRIPTION
## Problem

Mobile users were experiencing frequent logouts because the session cookie had no `maxAge` set, making it a session cookie that expires when the browser session ends. Mobile browsers aggressively terminate sessions when apps are backgrounded, causing immediate logouts.

## Solution

Added `maxAge: 7 * 24 * 60 * 60` to the session cookie configuration to persist it for 7 days, matching the database session expiration time. Desktop users stayed logged in longer because their browsers maintained sessions, but this fix ensures consistent behavior across all devices.

Fixes mobile logout issues without affecting authentication security.