### PR TITLE
Fix newsletter subscription redirect to /newsletter/check-email

### DIFF
--- a/src/lib/ui/NewsletterSubscribe.svelte
+++ b/src/lib/ui/NewsletterSubscribe.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import Button from './Button.svelte'
 	import SidebarCard from './SidebarCard.svelte'
-	import { Envelope, CheckCircle, Warning } from 'phosphor-svelte'
+	import { Envelope, Warning } from 'phosphor-svelte'
 	import { subscribeNewsletter } from './newsletter.remote'
-
-	let showSuccess = $state(false)
-	let errorMessage = $state('')
 </script>
 
 <SidebarCard title="Newsletter" padding="compact" data-testid="newsletter-subscribe">
@@ -13,59 +10,38 @@
 		<Envelope weight="bold" class="text-orange-600" />
 	{/snippet}
 
-	{#if showSuccess}
-		<div class="flex items-center gap-2 text-green-600" data-testid="newsletter-success">
-			<CheckCircle weight="fill" />
-			<span class="text-xs">Check your email to confirm!</span>
-		</div>
-	{:else}
-		<p class="text-xs text-gray-600">Get the latest Svelte news and resources delivered weekly.</p>
+	<p class="text-xs text-gray-600">Get the latest Svelte news and resources delivered weekly.</p>
 
-		<form
-			{...subscribeNewsletter.enhance(async ({ submit }) => {
-				errorMessage = ''
-				try {
-					await submit()
-					if (subscribeNewsletter.result?.success === true) {
-						showSuccess = true
-					} else {
-						errorMessage = subscribeNewsletter.result?.text || 'Failed to subscribe'
-					}
-				} catch {
-					errorMessage = 'An error occurred. Please try again.'
-				}
-			})}
-			class="flex flex-col gap-2"
+	<form {...subscribeNewsletter.for('newsletter-sidebar')} class="flex flex-col gap-2">
+		<input
+			type="email"
+			{...subscribeNewsletter.for('newsletter-sidebar').fields.email}
+			placeholder="your@email.com"
+			disabled={!!subscribeNewsletter.for('newsletter-sidebar').pending}
+			class="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm placeholder-slate-400 focus:border-orange-300 focus:outline-none focus:ring-1 focus:ring-orange-300 disabled:opacity-50"
+			data-testid="newsletter-email-input"
+		/>
+
+		{#if subscribeNewsletter.for('newsletter-sidebar').fields.email.issues()?.length}
+			<div class="flex items-center gap-1 text-xs text-red-600" data-testid="newsletter-error">
+				<Warning weight="fill" size={12} />
+				<span>{subscribeNewsletter.for('newsletter-sidebar').fields.email.issues()?.[0]}</span>
+			</div>
+		{/if}
+
+		<Button
+			type="submit"
+			size="sm"
+			disabled={!!subscribeNewsletter.for('newsletter-sidebar').pending}
+			data-testid="newsletter-submit"
 		>
-			<input
-				{...subscribeNewsletter.fields.email.as('email')}
-				placeholder="your@email.com"
-				disabled={!!subscribeNewsletter.pending}
-				class="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm placeholder-slate-400 focus:border-orange-300 focus:outline-none focus:ring-1 focus:ring-orange-300 disabled:opacity-50"
-				data-testid="newsletter-email-input"
-			/>
-
-			{#if errorMessage || subscribeNewsletter.fields.email.issues()?.length}
-				<div class="flex items-center gap-1 text-xs text-red-600" data-testid="newsletter-error">
-					<Warning weight="fill" size={12} />
-					<span>{errorMessage || subscribeNewsletter.fields.email.issues()?.[0]}</span>
-				</div>
-			{/if}
-
-			<Button
-				type="submit"
-				size="sm"
-				disabled={!!subscribeNewsletter.pending}
-				data-testid="newsletter-submit"
+			{subscribeNewsletter.for('newsletter-sidebar').pending ? 'Subscribing...' : 'Subscribe'}
+		</Button>
+		<p class="text-xs text-slate-500">
+			Data processed by Plunk. <a
+				href="/privacy"
+				class="text-svelte-900 hover:text-svelte-500 underline">Privacy Policy</a
 			>
-				{subscribeNewsletter.pending ? 'Subscribing...' : 'Subscribe'}
-			</Button>
-			<p class="text-xs text-slate-500">
-				Data processed by Plunk. <a
-					href="/privacy"
-					class="text-svelte-900 hover:text-svelte-500 underline">Privacy Policy</a
-				>
-			</p>
-		</form>
-	{/if}
+		</p>
+	</form>
 </SidebarCard>

--- a/src/lib/ui/newsletter.remote.ts
+++ b/src/lib/ui/newsletter.remote.ts
@@ -16,8 +16,8 @@ export const subscribeNewsletter = form(subscribeSchema, async (data) => {
 	// 1. Check if already subscribed in Plunk (silent success - don't reveal this)
 	const existingContact = await locals.emailService.getContact(email)
 	if (existingContact?.subscribed) {
-		// Already subscribed - return success to prevent email enumeration
-		return { success: true }
+		// Already subscribed - redirect to prevent email enumeration
+		redirect(303, '/newsletter/check-email')
 	}
 
 	// 2. Create/update pending subscription with new token
@@ -45,7 +45,7 @@ export const subscribeNewsletter = form(subscribeSchema, async (data) => {
 		locals.userService.updateNewsletterPreference(locals.user.id, 'subscribed')
 	}
 
-	return { success: true }
+	redirect(303, '/newsletter/check-email')
 })
 
 export const userDecline = form(z.object({}), async () => {

--- a/src/routes/(app)/(public)/newsletter/subscribe/+page.svelte
+++ b/src/routes/(app)/(public)/newsletter/subscribe/+page.svelte
@@ -10,10 +10,10 @@
 
 <div class="space-y-4 max-w-lg mx-auto" data-testid="newsletter-subscribe-page">
 	<h2 class="mb-4 text-xl font-bold">Newsletter</h2>
-	{#if subscribeNewsletter.result?.success}
+	{#if subscribeNewsletter.for('newsletter-page').result?.success}
 		<div class="flex items-center gap-2 text-green-600" data-testid="newsletter-success">
 			<CheckCircle weight="fill" class="size-5" />
-			<span class="text-sm">{subscribeNewsletter.result.text}</span>
+			<span class="text-sm">{subscribeNewsletter.for('newsletter-page').result.text}</span>
 		</div>
 	{:else}
 		<div class="flex items-center gap-3">
@@ -47,19 +47,20 @@
 			</li>
 		</ul>
 
-		<form {...subscribeNewsletter.for('subscribe-page')} class="space-y-3">
+		<form {...subscribeNewsletter.for('newsletter-page')} class="space-y-3">
 			<Input
-				{...subscribeNewsletter.fields.email.as('email')}
+				type="email"
+				{...subscribeNewsletter.for('newsletter-page').fields.email}
 				placeholder="your@email.com"
-				issues={subscribeNewsletter.fields.email.issues()}
+				issues={subscribeNewsletter.for('newsletter-page').fields.email.issues()}
 			/>
 			<div class="mt-3 flex gap-2">
 				<Button
 					type="submit"
-					disabled={!!subscribeNewsletter.pending}
+					disabled={!!subscribeNewsletter.for('newsletter-page').pending}
 					data-testid="newsletter-subscribe-btn"
 				>
-					{subscribeNewsletter.pending ? 'Subscribing...' : 'Yes, subscribe me'}
+					{subscribeNewsletter.for('newsletter-page').pending ? 'Subscribing...' : 'Yes, subscribe me'}
 				</Button>
 				<Button
 					variant="ghost"


### PR DESCRIPTION
## Summary
- Changed newsletter subscription handler to redirect users to `/newsletter/check-email` confirmation page instead of returning inline success state
- Updated both newsletter form components to use Remote Functions `.for()` pattern with proper field scoping
- All 39 newsletter E2E tests passing

## Changes
- `newsletter.remote.ts`: Added `redirect(303)` to check-email route on successful subscription
- `NewsletterSubscribe.svelte`: Removed `.enhance()` wrapper, now uses `.for('newsletter-sidebar')` pattern
- `newsletter/subscribe` page: Updated to use `.for('newsletter-page')` pattern consistently with proper field binding