### PR TITLE
Fix newsletter subscription errors in sidebar and modal

### DIFF
--- a/src/lib/ui/NewsletterSubscribe.svelte
+++ b/src/lib/ui/NewsletterSubscribe.svelte
@@ -25,7 +25,7 @@
 		{#if subscribeNewsletter.for('newsletter-sidebar').fields.email.issues()?.length}
 			<div class="flex items-center gap-1 text-xs text-red-600" data-testid="newsletter-error">
 				<Warning weight="fill" size={12} />
-				<span>{subscribeNewsletter.for('newsletter-sidebar').fields.email.issues()?.[0]}</span>
+				<span>{subscribeNewsletter.for('newsletter-sidebar').fields.email.issues()?.[0]?.message}</span>
 			</div>
 		{/if}
 

--- a/src/routes/(app)/_components/RightSidebar.svelte
+++ b/src/routes/(app)/_components/RightSidebar.svelte
@@ -38,7 +38,7 @@
 
 	<UpcomingEvents events={upcomingEvents} />
 
-	{#if user?.newsletter_preference !== 'subscribed'}
+	{#if user?.newsletter_preference === 'declined' || !user}
 		<NewsletterSubscribe />
 	{/if}
 </aside>


### PR DESCRIPTION
## Summary

Fixes two issues when subscribing to the newsletter:

- Sidebar error displays as `[object Object]` instead of the actual validation message
- Opening newsletter modal throws "form can only be attached to a single element" error

## Changes

- **NewsletterSubscribe.svelte**: Access `.message` property to display error text properly
- **RightSidebar.svelte**: Only show sidebar newsletter when user is logged out or has explicitly declined, preventing form conflict with modal

## Testing

All 39 newsletter E2E tests pass.