### PR TITLE
Fix newsletter subscription field type handling

### DIFF
--- a/src/lib/ui/NewsletterSubscribe.svelte
+++ b/src/lib/ui/NewsletterSubscribe.svelte
@@ -14,8 +14,7 @@
 
 	<form {...subscribeNewsletter} class="flex flex-col gap-2">
 		<input
-			type="email"
-			{...subscribeNewsletter.fields.email}
+			{...subscribeNewsletter.fields.email.as('email')}
 			placeholder="your@email.com"
 			disabled={!!subscribeNewsletter.pending}
 			class="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm placeholder-slate-400 focus:border-orange-300 focus:outline-none focus:ring-1 focus:ring-orange-300 disabled:opacity-50"

--- a/src/routes/(app)/(public)/newsletter/subscribe/+page.svelte
+++ b/src/routes/(app)/(public)/newsletter/subscribe/+page.svelte
@@ -49,8 +49,7 @@
 
 		<form {...subscribePageNewsletter} class="space-y-3">
 			<Input
-				type="email"
-				{...subscribePageNewsletter.fields.email}
+				{...subscribePageNewsletter.fields.email.as('email')}
 				placeholder="your@email.com"
 				issues={subscribePageNewsletter.fields.email.issues()}
 			/>


### PR DESCRIPTION
Use .as('email') method to properly set field type on email inputs in both the sidebar component and subscribe page form.