### PR TITLE
Display job tags and collection previews on cards

### DIFF
--- a/src/lib/ui/ContentCard.svelte
+++ b/src/lib/ui/ContentCard.svelte
@@ -146,7 +146,7 @@
 	}
 </script>
 
-{#if layout === 'horizontal'}
+{#if layout === 'horizontal' && content.type !== 'collection'}
 	<!-- Horizontal layout: Thumbnail | Content with likes/saves at top -->
 	<article
 		data-testid="content-card"
@@ -303,7 +303,9 @@
 
 			<!-- Tags + Date -->
 			<div class="mt-4 grid grid-cols-[1fr_auto] items-end gap-2">
-				{#if content.type !== 'job' && content.tags}
+				{#if content.type === 'job'}
+					<Job {content} variant="list" />
+				{:else if content.tags}
 					<div class="flex flex-wrap gap-1">
 						<Tags tags={content.tags as any} />
 					</div>
@@ -361,7 +363,9 @@
 
 		<!-- Row 3: Tags + Date (spans both columns, desktop only) -->
 		<div class="col-span-2 hidden grid-cols-[1fr_auto] items-end gap-2 sm:grid">
-			{#if content.type !== 'job' && content.tags}
+			{#if content.type === 'job'}
+				<Job {content} variant="list" />
+			{:else if content.tags}
 				<div class="flex flex-wrap gap-1">
 					<Tags tags={content.tags as any} />
 				</div>
@@ -556,7 +560,7 @@
 				{#if content.type === 'recipe'}
 					<Recipe {content} {variant} />
 				{:else if content.type === 'collection'}
-					<Collection children={content.children} />
+					<Collection children={content.children} slug={content.slug} {variant} />
 				{:else if content.type === 'video'}
 					<Video {content} {priority} />
 				{:else if content.type === 'library'}

--- a/src/lib/ui/content/Collection.svelte
+++ b/src/lib/ui/content/Collection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ContentWithAuthor } from '$lib/types/content'
+	import type { CardVariant } from '../contentCard.variants'
 	import { formatRelativeDate } from '$lib/utils/date'
 	import ArrowSquareOut from 'phosphor-svelte/lib/ArrowSquareOut'
 
@@ -7,9 +8,18 @@
 
 	interface Props {
 		children: ContentChild[]
+		slug?: string
+		variant?: CardVariant
 	}
 
-	let { children = [] }: Props = $props()
+	const PREVIEW_COUNT = 2
+
+	let { children = [], slug, variant = 'list' }: Props = $props()
+
+	const visibleChildren = $derived(
+		variant === 'list' ? children.slice(0, PREVIEW_COUNT) : children
+	)
+	const remainingCount = $derived(children.length - PREVIEW_COUNT)
 
 	function getAuthor(content: ContentChild): string {
 		return content?.author_name || content?.author_username || 'Unknown'
@@ -30,7 +40,7 @@
 </script>
 
 <ul class="space-y-2">
-	{#each children as child (child.id)}
+	{#each visibleChildren as child (child.id)}
 		<li
 			class="rounded border border-slate-200 bg-slate-100 px-3 py-1.5 shadow-sm transition-all hover:bg-slate-50 hover:shadow-md"
 		>
@@ -64,3 +74,12 @@
 		</li>
 	{/each}
 </ul>
+
+{#if variant === 'list' && remainingCount > 0}
+	<a
+		href="/collection/{slug}"
+		class="mt-2 flex items-center justify-center gap-1.5 rounded border border-slate-200 bg-slate-100 px-3 py-3 text-sm font-medium text-gray-600 shadow-sm transition-all hover:bg-slate-50 hover:text-gray-800 hover:shadow-md"
+	>
+		+{remainingCount} more item{remainingCount === 1 ? '' : 's'}
+	</a>
+{/if}

--- a/src/lib/ui/newsletter.remote.ts
+++ b/src/lib/ui/newsletter.remote.ts
@@ -1,102 +1,102 @@
-import { form, getRequestEvent } from "$app/server";
-import { redirect } from "@sveltejs/kit";
-import { dev } from "$app/environment";
-import { z } from "zod/v4";
+import { form, getRequestEvent } from '$app/server'
+import { redirect } from '@sveltejs/kit'
+import { dev } from '$app/environment'
+import { z } from 'zod/v4'
 
 const subscribeSchema = z.object({
-  email: z.email("Please enter a valid email address"),
-});
+	email: z.email('Please enter a valid email address')
+})
 
-const BASE_URL = dev ? "http://localhost:5173" : "https://sveltesociety.dev";
+const BASE_URL = dev ? 'http://localhost:5173' : 'https://sveltesociety.dev'
 
 export const subscribeNewsletter = form(subscribeSchema, async (data) => {
-  const { locals } = getRequestEvent();
-  const email = data.email.toLowerCase().trim();
+	const { locals } = getRequestEvent()
+	const email = data.email.toLowerCase().trim()
 
-  // 1. Check if already subscribed in Plunk (silent success - don't reveal this)
-  const existingContact = await locals.emailService.getContact(email);
-  if (existingContact?.subscribed) {
-    // Already subscribed - redirect to prevent email enumeration
-    redirect(303, "/newsletter/check-email");
-  }
+	// 1. Check if already subscribed in Plunk (silent success - don't reveal this)
+	const existingContact = await locals.emailService.getContact(email)
+	if (existingContact?.subscribed) {
+		// Already subscribed - redirect to prevent email enumeration
+		redirect(303, '/newsletter/check-email')
+	}
 
-  // 2. Create/update pending subscription with new token
-  // Pass user ID if logged in, so we can update their plunk_contact_id after confirmation
-  const { token } = locals.newsletterService.createPendingSubscription(email, locals.user?.id);
+	// 2. Create/update pending subscription with new token
+	// Pass user ID if logged in, so we can update their plunk_contact_id after confirmation
+	const { token } = locals.newsletterService.createPendingSubscription(email, locals.user?.id)
 
-  // 3. Send confirmation email
-  const emailSent = await locals.emailService.sendNewsletterConfirmationEmail({
-    email,
-    token,
-    baseUrl: BASE_URL,
-  });
+	// 3. Send confirmation email
+	const emailSent = await locals.emailService.sendNewsletterConfirmationEmail({
+		email,
+		token,
+		baseUrl: BASE_URL
+	})
 
-  if (!emailSent) {
-    console.error("Failed to send confirmation email to:", email);
-    return { success: false, text: "Failed to send confirmation email. Please try again." };
-  }
+	if (!emailSent) {
+		console.error('Failed to send confirmation email to:', email)
+		return { success: false, text: 'Failed to send confirmation email. Please try again.' }
+	}
 
-  // 4. Opportunistically clean up expired tokens
-  locals.newsletterService.cleanupExpired();
+	// 4. Opportunistically clean up expired tokens
+	locals.newsletterService.cleanupExpired()
 
-  // 5. If user is logged in, mark them as subscribed immediately
-  // This prevents the modal from reappearing while they confirm their email
-  if (locals.user) {
-    locals.userService.updateNewsletterPreference(locals.user.id, "subscribed");
-  }
+	// 5. If user is logged in, mark them as subscribed immediately
+	// This prevents the modal from reappearing while they confirm their email
+	if (locals.user) {
+		locals.userService.updateNewsletterPreference(locals.user.id, 'subscribed')
+	}
 
-  redirect(303, "/newsletter/check-email");
-});
+	redirect(303, '/newsletter/check-email')
+})
 
 export const subscribePageNewsletter = form(subscribeSchema, async (data) => {
-  const { locals } = getRequestEvent();
-  const email = data.email.toLowerCase().trim();
+	const { locals } = getRequestEvent()
+	const email = data.email.toLowerCase().trim()
 
-  // 1. Check if already subscribed in Plunk (silent success - don't reveal this)
-  const existingContact = await locals.emailService.getContact(email);
-  if (existingContact?.subscribed) {
-    // Already subscribed - redirect to prevent email enumeration
-    redirect(303, "/newsletter/check-email");
-  }
+	// 1. Check if already subscribed in Plunk (silent success - don't reveal this)
+	const existingContact = await locals.emailService.getContact(email)
+	if (existingContact?.subscribed) {
+		// Already subscribed - redirect to prevent email enumeration
+		redirect(303, '/newsletter/check-email')
+	}
 
-  // 2. Create/update pending subscription with new token
-  // Pass user ID if logged in, so we can update their plunk_contact_id after confirmation
-  const { token } = locals.newsletterService.createPendingSubscription(email, locals.user?.id);
+	// 2. Create/update pending subscription with new token
+	// Pass user ID if logged in, so we can update their plunk_contact_id after confirmation
+	const { token } = locals.newsletterService.createPendingSubscription(email, locals.user?.id)
 
-  // 3. Send confirmation email
-  const emailSent = await locals.emailService.sendNewsletterConfirmationEmail({
-    email,
-    token,
-    baseUrl: BASE_URL,
-  });
+	// 3. Send confirmation email
+	const emailSent = await locals.emailService.sendNewsletterConfirmationEmail({
+		email,
+		token,
+		baseUrl: BASE_URL
+	})
 
-  if (!emailSent) {
-    console.error("Failed to send confirmation email to:", email);
-    return { success: false, text: "Failed to send confirmation email. Please try again." };
-  }
+	if (!emailSent) {
+		console.error('Failed to send confirmation email to:', email)
+		return { success: false, text: 'Failed to send confirmation email. Please try again.' }
+	}
 
-  // 4. Opportunistically clean up expired tokens
-  locals.newsletterService.cleanupExpired();
+	// 4. Opportunistically clean up expired tokens
+	locals.newsletterService.cleanupExpired()
 
-  // 5. If user is logged in, mark them as subscribed immediately
-  // This prevents the modal from reappearing while they confirm their email
-  if (locals.user) {
-    locals.userService.updateNewsletterPreference(locals.user.id, "subscribed");
-  }
+	// 5. If user is logged in, mark them as subscribed immediately
+	// This prevents the modal from reappearing while they confirm their email
+	if (locals.user) {
+		locals.userService.updateNewsletterPreference(locals.user.id, 'subscribed')
+	}
 
-  redirect(303, "/newsletter/check-email");
-});
+	redirect(303, '/newsletter/check-email')
+})
 
 export const userDecline = form(z.object({}), async () => {
-  const { locals } = getRequestEvent();
+	const { locals } = getRequestEvent()
 
-  if (!locals.user) {
-    return { success: false, text: "You must be logged in" };
-  }
+	if (!locals.user) {
+		return { success: false, text: 'You must be logged in' }
+	}
 
-  const updated = locals.userService.updateNewsletterPreference(locals.user.id, "declined");
-  return {
-    success: updated,
-    text: updated ? "Preference saved" : "Failed to save preference",
-  };
-});
+	const updated = locals.userService.updateNewsletterPreference(locals.user.id, 'declined')
+	return {
+		success: updated,
+		text: updated ? 'Preference saved' : 'Failed to save preference'
+	}
+})


### PR DESCRIPTION
## Summary
- Added job metadata badges (position type, seniority level, remote status, salary) to horizontal layout content cards
- Added collection children preview showing first 2 items with styled "+X more" link
- Collections always use vertical layout for better readability

## Test plan
- Browse jobs listing and verify badges display in horizontal layout
- Browse collections listing and verify first 2 children show with "+X more" link
- Click "+X more" link and verify navigation to full collection
- Verify collection detail pages show all children