### PR TITLE
Fix author filter returning zero results on homepage

### DIFF
--- a/src/lib/server/services/content.ts
+++ b/src/lib/server/services/content.ts
@@ -517,9 +517,16 @@ export class ContentService {
 			if (updatedContent) {
 				// Get tag slugs for search index
 				const tagSlugs = updatedContent.tags?.map((tag) => tag.slug) || []
-				// Get author names for search index
-				const authorNames =
-					updatedContent.authors?.map((author) => author.name || author.username) || []
+				// Get author names for search index from junction table
+				const authorRows = this.db
+					.prepare(
+						`SELECT COALESCE(u.name, u.username) as author_name
+						FROM content_to_users cu
+						JOIN users u ON cu.user_id = u.id
+						WHERE cu.content_id = ?`
+					)
+					.all(data.id) as { author_name: string }[]
+				const authorNames = authorRows.map((a) => a.author_name)
 
 				this.searchService.update(data.id, {
 					id: updatedContent.id,


### PR DESCRIPTION
## Summary
Fixes the author filter on the homepage returning zero results even when posts exist from that author. The issue occurred because the `updateContent` method tried to read authors from a non-existent `authors` array, causing the Orama search index to progressively lose author data as content was edited.

## Root Cause
`getContentById()` returns a flat object with scalar fields like `author_username` and `author_name`, not an `authors` array. The broken code tried to map over `updatedContent.authors`, which was always `undefined`, resulting in `authorNames` always being empty.

## Solution
Query `content_to_users` directly to get author names, matching how the initial Orama index is built during service initialization.

## Testing
- Author profile pages (which query the database) continue to work
- Author filter on homepage now returns correct results
- Editing content no longer corrupts the search index